### PR TITLE
Add address errors in trying to process extensions

### DIFF
--- a/app/facades/canvas_facade.rb
+++ b/app/facades/canvas_facade.rb
@@ -364,7 +364,7 @@ class CanvasFacade < LmsFacade
     end
 
     all_assignment_overrides.each do |override|
-      return override if override&.student_ids.map(&:to_i)&.include?(student_id.to_i)
+      return override if override&.student_ids&.map(&:to_i)&.include?(student_id.to_i)
     end
     nil
   end

--- a/spec/facades/canvas_facade_spec.rb
+++ b/spec/facades/canvas_facade_spec.rb
@@ -475,6 +475,24 @@ describe CanvasFacade do
                assignment_id
              )).to be_nil
     end
+
+    it 'skips overrides with nil student_ids' do
+      mock_override_nil_students = mock_override.clone
+      mock_override_nil_students[:student_ids] = nil
+      stubs.get(get_assignment_overrides_url) do
+        [
+          200,
+          {},
+          [ mock_override_nil_students, mock_override ].to_json
+        ]
+      end
+      expect(facade.send(
+               :get_existing_student_override,
+               course_id,
+               student_id,
+               assignment_id
+             ).student_ids[0]).to eq(student_id)
+    end
   end
 
   describe 'get_current_formatted_time' do


### PR DESCRIPTION
Tina ran into an error where the override is returned successfully but there is no list of student ids. 

This seems like it can happen if an override is for a group or section, or the students were deleted. There probably could be more testing here. 

---

See if you can fix this error approving a request

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/qGfwDtBttCqM/implementations/mNpCTf77ct6m) | [App Preview](https://www.superconductor.com/tickets/qGfwDtBttCqM/implementations/mNpCTf77ct6m/preview)

<!-- created-by-superconductor -->