### PR TITLE
Publish developers doc

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,7 +1,6 @@
 ---
 title: Developing Flextensions
 permalink: /developers/
-published: false
 ---
 
 # Standing Up the Application


### PR DESCRIPTION
Removed `published: false` in `developers.md` so that https://berkeley-cdss.github.io/flextensions/developers works. Fixes #264.