### PR TITLE
Add semester field to courses

### DIFF
--- a/app/facades/canvas_facade.rb
+++ b/app/facades/canvas_facade.rb
@@ -195,7 +195,7 @@ class CanvasFacade < LmsFacade
   # @param  [Integer] courseId the course id to look up.
   # @return [Faraday::Response] information about the requested course.
   def get_course(courseId)
-    @canvas_conn.get("courses/#{courseId}")
+    @canvas_conn.get("courses/#{courseId}", { 'include[]': 'term' })
   end
 
   ##

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -35,6 +35,9 @@ class Course < ApplicationRecord
   validates :course_name, presence: true
   # validate :ensure_course_settings
 
+  # Scopes
+  scope :by_semester, ->(semester) { where(semester: semester) }
+
   # Always load the LMS integrations
   default_scope { includes(:course_to_lmss) }
 
@@ -198,6 +201,8 @@ class Course < ApplicationRecord
     response_data = JSON.parse(response.body)
     course.course_name = response_data['name']
     course.course_code = response_data['course_code']
+    # Semester is sourced from the Canvas term name (e.g. "Spring 2026")
+    course.semester = response_data.dig('term', 'name')
     course.save!
     course
   end

--- a/db/migrate/20260306000001_add_semester_to_courses.rb
+++ b/db/migrate/20260306000001_add_semester_to_courses.rb
@@ -1,0 +1,5 @@
+class AddSemesterToCourses < ActiveRecord::Migration[7.2]
+  def change
+    add_column :courses, :semester, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_02_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_06_000001) do
   create_schema "hypershield"
 
   # These are extensions that must be enabled in order to support this database
@@ -127,6 +127,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_02_000001) do
     t.string "canvas_id"
     t.string "course_code"
     t.string "readonly_api_token"
+    t.string "semester"
     t.index ["canvas_id"], name: "index_courses_on_canvas_id", unique: true
     t.index ["readonly_api_token"], name: "index_courses_on_readonly_api_token", unique: true
   end

--- a/lib/tasks/backfill_course_semester.rake
+++ b/lib/tasks/backfill_course_semester.rake
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+namespace :courses do
+  desc 'Backfill semester for existing courses by fetching term data from Canvas'
+  task backfill_semester: :environment do
+    puts 'Starting backfill of semester for all courses...'
+
+    total = Course.count
+    updated_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    Course.find_each do |course|
+      if course.semester.present?
+        skipped_count += 1
+        next
+      end
+
+      # Find a staff user with Canvas credentials to make the API call
+      staff_user = course.staff_user_for_auto_approval
+      if staff_user.nil?
+        puts "No staff user found for course #{course.id} (#{course.course_name}) - skipping"
+        failed_count += 1
+        next
+      end
+
+      token = staff_user.canvas_token
+      if token.blank?
+        puts "No Canvas token for staff user on course #{course.id} (#{course.course_name}) - skipping"
+        failed_count += 1
+        next
+      end
+
+      begin
+        response = CanvasFacade.new(token).get_course(course.canvas_id)
+        if response&.success?
+          data = JSON.parse(response.body)
+          semester = data.dig('term', 'name')
+          if semester.present?
+            course.update!(semester: semester)
+            updated_count += 1
+            puts "Updated course #{course.id} (#{course.course_name}) -> #{semester}"
+          else
+            puts "No term data for course #{course.id} (#{course.course_name}) - skipping"
+            failed_count += 1
+          end
+        else
+          puts "API request failed for course #{course.id} (#{course.course_name}) - skipping"
+          failed_count += 1
+        end
+      rescue StandardError => e
+        puts "Error for course #{course.id} (#{course.course_name}): #{e.message}"
+        failed_count += 1
+      end
+    end
+
+    puts "\nBackfill complete!"
+    puts "Total courses: #{total}"
+    puts "Updated: #{updated_count}"
+    puts "Skipped (already set): #{skipped_count}"
+    puts "Failed: #{failed_count}"
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     sequence(:course_name) { |n| "Course #{n}" }
     sequence(:canvas_id, &:to_s)
     sequence(:course_code) { |n| "COURSE#{n}" }
+    semester { 'Spring 2026' }
 
     after(:create) do |course|
       lms = Lms.find_by(id: 1) || create(:lms, id: 1, lms_name: 'Canvas')

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -105,6 +105,44 @@ RSpec.describe Course, type: :model do
       expect(course.course_name).to eq('Intro to RSpec')
       expect(course.course_code).to eq('RSPEC101')
     end
+
+    it 'stores semester from Canvas term data' do
+      stub_request(:get, %r{api/v1/courses/canvas_123})
+        .to_return(status: 200, body: {
+          name: 'Intro to RSpec',
+          course_code: 'RSPEC101',
+          term: { name: 'Spring 2026' }
+        }.to_json)
+
+      course = described_class.find_or_create_course(course_data, token)
+
+      expect(course.semester).to eq('Spring 2026')
+    end
+
+    it 'handles missing term data gracefully' do
+      stub_request(:get, %r{api/v1/courses/canvas_123})
+        .to_return(status: 200, body: { name: 'Intro to RSpec', course_code: 'RSPEC101' }.to_json)
+
+      course = described_class.find_or_create_course(course_data, token)
+
+      expect(course.semester).to be_nil
+    end
+
+    it 'updates semester on existing course when Canvas term changes' do
+      described_class.create!(canvas_id: 'canvas_123', course_name: 'Intro to RSpec',
+                              course_code: 'RSPEC101', semester: 'Fall 2025')
+
+      stub_request(:get, %r{api/v1/courses/canvas_123})
+        .to_return(status: 200, body: {
+          name: 'Intro to RSpec',
+          course_code: 'RSPEC101',
+          term: { name: 'Spring 2026' }
+        }.to_json)
+
+      course = described_class.find_or_create_course(course_data, token)
+
+      expect(course.semester).to eq('Spring 2026')
+    end
   end
 
   describe '.find_or_create_course_to_lms' do
@@ -138,6 +176,19 @@ end
       end.to change(User, :count).by(CANVAS_USERS.size).and(
         change(UserToCourse, :count).by(CANVAS_USERS.size)
       )
+    end
+  end
+
+  describe '.by_semester' do
+    it 'returns only courses matching the given semester' do
+      spring = described_class.create!(canvas_id: 'c1', course_name: 'Course A', course_code: 'A', semester: 'Spring 2026')
+      fall = described_class.create!(canvas_id: 'c2', course_name: 'Course B', course_code: 'B', semester: 'Fall 2025')
+      described_class.create!(canvas_id: 'c3', course_name: 'Course C', course_code: 'C', semester: nil)
+
+      results = described_class.by_semester('Spring 2026')
+
+      expect(results).to contain_exactly(spring)
+      expect(results).not_to include(fall)
     end
   end
 


### PR DESCRIPTION
## Changes
- Added database migration to add `semester` string column to the `courses` table
- Course model populates semester from Canvas term data (e.g. "Spring 2026") when importing courses
- Added `by_semester` scope to Course model for filtering courses by semester
- Added backfill rake task (`rake courses:backfill_semester`) to populate semester for existing courses by fetching term data from Canvas API

## Testing
- Run `bundle exec rspec` to verify all tests pass
- After deploying, run the migration and backfill task:
  ```
  heroku run rails db:migrate -a sp26-02-flextensions
  heroku run rake courses:backfill_semester -a sp26-02-flextensions
  ```

## Documentation
No documentation needed

## Checklist
- [x] Name of branch corresponds to story
- [x] 80%+ test coverage with all tests passing