### PR TITLE
Refactor permissions logic with Pundit gem and write policies for user roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'omniauth'
 gem 'omniauth-canvas'
 gem 'omniauth-oauth2'
 
+# Authorization
+gem 'pundit'
+
 # Audit for potentially unsafe database migrations
 gem 'strong_migrations'
 
@@ -111,6 +114,7 @@ group :test do
   gem 'rack_session_access'
   gem 'rspec-retry'
   gem 'selenium-webdriver'
+  gem 'pundit-matchers', '~> 3.1'
   gem 'shoulda-matchers', '~> 7.0'
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'simplecov_json_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,13 @@ GEM
     public_suffix (7.0.5)
     puma (7.2.0)
       nio4r (~> 2.0)
+    pundit (2.5.2)
+      activesupport (>= 3.0.0)
+    pundit-matchers (3.1.2)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
     racc (1.8.1)
     rack (3.2.6)
     rack-protection (4.2.1)
@@ -643,6 +650,8 @@ DEPENDENCIES
   ostruct
   pg
   puma (>= 6.0)
+  pundit
+  pundit-matchers (~> 3.1)
   rack_session_access
   rails (~> 7.2.3.1)
   rails-controller-testing (~> 1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,10 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+
   before_action :authenticated!, unless: -> { excluded_controller_action? }
 
   rescue_from LmsFacade::LmsAPIError, with: :handle_lms_api_error
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def excluded_controller_action?
     # Actions and controllers that do NOT require authentication
@@ -126,5 +129,14 @@ class ApplicationController < ActionController::Base
 
     flash[:alert] = 'You do not have access to this page.'
     redirect_to courses_path
+  end
+
+  def pundit_user
+    current_user
+  end
+
+  def user_not_authorized
+    flash[:alert] = 'You do not have access to this page.'
+    redirect_back_or_to(courses_path)
   end
 end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,18 +1,12 @@
 class AssignmentsController < ApplicationController
   def toggle_enabled
     @assignment = Assignment.find(params[:id])
-    course = @assignment.course_to_lms.course
-    @role = params[:role] || course&.user_role(@user)
-
-    unless @role == 'instructor'
-      Rails.logger.error "Role #{@role} does not have permission to toggle assignment enabled status"
-      flash.now[:alert] = 'You do not have permission to perform this action.'
-      return render json: { redirect_to: course_path(course) }, status: :forbidden
-    end
+    authorize @assignment
 
     if @assignment.update(enabled: params[:enabled])
       render json: { success: true }, status: :ok
     else
+      course = @assignment.course_to_lms.course
       flash[:alert] = "Failed to update assignment: #{@assignment.errors.full_messages.to_sentence}"
       render json: { redirect_to: course_path(course) }, status: :unprocessable_content
     end

--- a/app/controllers/course_settings_controller.rb
+++ b/app/controllers/course_settings_controller.rb
@@ -2,7 +2,6 @@ class CourseSettingsController < ApplicationController
   before_action :authenticated!
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_instructor_role
   before_action :set_pending_request_count
 
   # Default template settings
@@ -21,6 +20,7 @@ class CourseSettingsController < ApplicationController
   def update
     @side_nav = 'course_settings'
     @course_settings = @course.course_settings || @course.build_course_settings
+    authorize @course_settings
 
     if params[:reset_email_template].present?
       reset_email_templates

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,7 +5,8 @@ class CoursesController < ApplicationController
   before_action :determine_user_role
 
   def index
-    @teacher_courses = UserToCourse.includes(:course).where(user: @user, role: %w[teacher ta])
+    authorize Course
+    @teacher_courses = UserToCourse.includes(:course).where(user: @user, role: UserToCourse.staff_roles)
 
     # Only show courses to students if extensions are enabled at the course level
     student_courses = UserToCourse.includes(course: :course_settings).where(user: @user, role: 'student')
@@ -17,6 +18,8 @@ class CoursesController < ApplicationController
 
   def show
     return redirect_to courses_path, alert: 'Course not found.' unless @course
+
+    authorize @course
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless @course.has_canvas_linked?
 
     @side_nav = 'show'
@@ -34,6 +37,7 @@ class CoursesController < ApplicationController
   end
 
   def new
+    authorize Course
     token = @user.lms_credentials.first.token
     @courses = Course.fetch_courses(token)
     flash[:alert] = 'No courses found.' if @courses.empty?
@@ -56,11 +60,12 @@ class CoursesController < ApplicationController
   end
 
   def edit
+    authorize @course
     @side_nav = 'edit'
-    redirect_to course_path(@course.id), alert: 'You do not have access to this page.' unless @role == 'instructor'
   end
 
   def create
+    authorize Course
     token = @user.lms_credentials.first.token
     filter_courses(Course.fetch_courses(token), %w[teacher ta])
       .select { |c| params[:courses]&.include?(c['id'].to_s) }
@@ -71,6 +76,7 @@ class CoursesController < ApplicationController
   def sync_assignments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
 
+    authorize @course
     @course.sync_assignments(@user)
     render json: { message: 'Assignments synced successfully.' }, status: :ok
   end
@@ -78,20 +84,21 @@ class CoursesController < ApplicationController
   def sync_enrollments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
 
+    authorize @course
     @course.sync_all_enrollments_from_canvas(@user.id)
     render json: { message: 'Users synced successfully.' }, status: :ok
   end
 
   def enrollments
+    authorize @course
     @side_nav = 'enrollments'
-    return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
 
     @enrollments = @course.user_to_courses.includes(:user)
     @is_course_admin = @course.user_to_courses.find_by(user: @user)&.course_admin?
   end
 
   def delete
-    return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
+    authorize @course
     return redirect_to courses_path, alert: 'Extensions are enabled for this course.' if @course.course_settings&.enable_extensions
 
     assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: @course.id).select(:id))

--- a/app/controllers/form_settings_controller.rb
+++ b/app/controllers/form_settings_controller.rb
@@ -2,17 +2,18 @@ class FormSettingsController < ApplicationController
   before_action :authenticated!
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_instructor_role
   before_action :set_pending_request_count
 
   def edit
-    @side_nav = 'form_settings'
     @form_setting = @course.form_setting
+    authorize @form_setting
+    @side_nav = 'form_settings'
   end
 
   def update
     @side_nav = 'form_settings'
     @form_setting = @course.form_setting || @course.build_form_setting
+    authorize @form_setting
 
     permitted = form_setting_params.to_h
     defaulted = {

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -11,9 +11,9 @@ class RequestsController < ApplicationController
   before_action :check_extensions_enabled_for_students, except: [ :export ]
   before_action :ensure_request_is_pending, only: %i[update approve reject]
   before_action :set_request, only: %i[show edit cancel]
-  before_action :check_instructor_permission, only: %i[approve reject mass_approve mass_reject]
 
   def index
+    authorize @course, :show?
     @side_nav = 'requests'
     if @role == 'student'
       @requests = @course.requests.for_user(@user)
@@ -30,12 +30,14 @@ class RequestsController < ApplicationController
   end
 
   def show
+    authorize @request
     @assignment = @request.assignment
     @number_of_days = @request.calculate_days_difference if @request.requested_due_date.present? && @assignment&.due_date.present?
     render_role_based_view
   end
 
   def new
+    authorize @course, :show?
     @side_nav = 'form'
     # course_to_lms = @course.course_to_lms(1)
     course_to_lmss = @course.all_linked_lmss.pluck(:id)
@@ -55,8 +57,8 @@ class RequestsController < ApplicationController
   end
 
   def new_for_student
+    authorize @course, policy_class: RequestPolicy
     @side_nav = 'form'
-    return redirect_to course_requests_path(@course), alert: 'You do not have permission to access this page.' unless @role == 'instructor'
 
     course_to_lmss = @course.all_linked_lmss.pluck(:id)
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
@@ -91,7 +93,7 @@ class RequestsController < ApplicationController
   end
 
   def create_for_student
-    return redirect_to course_requests_path(@course), alert: 'You do not have permission to perform this action.' unless @role == 'instructor'
+    authorize @course, policy_class: RequestPolicy
 
     student = User.find_by(id: params[:request][:user_id])
     return redirect_to new_course_request_path(@course), alert: 'Student not found.' unless student
@@ -134,6 +136,7 @@ class RequestsController < ApplicationController
   end
 
   def approve
+    authorize @request
     @assignment = Assignment.find_by(id: @request.assignment_id)
     lms_facade = @assignment.lms_facade
     if @request.approve(lms_facade.from_user(@user), @user)
@@ -152,6 +155,7 @@ class RequestsController < ApplicationController
   end
 
   def reject
+    authorize @request
     if @request.reject(@user)
       notice = 'Request denied successfully.'
       respond_to do |format|
@@ -168,10 +172,12 @@ class RequestsController < ApplicationController
   end
 
   def mass_approve
+    authorize @course, policy_class: RequestPolicy
     process_mass_action(:approve)
   end
 
   def mass_reject
+    authorize @course, policy_class: RequestPolicy
     process_mass_action(:reject)
   end
 
@@ -194,11 +200,6 @@ class RequestsController < ApplicationController
     @side_nav = 'requests'
     @request = @course.requests.includes(:assignment).find_by(id: params[:id])
     redirect_to course_path(@course), alert: 'Request not found.' unless @request
-  end
-
-  def check_instructor_permission
-    result = RequestService.check_instructor_permission(@role, course_path(@course))
-    redirect_to result[:redirect_to], alert: result[:alert] if result != true
   end
 
   def handle_request_error

--- a/app/controllers/user_to_courses_controller.rb
+++ b/app/controllers/user_to_courses_controller.rb
@@ -1,10 +1,10 @@
 class UserToCoursesController < ApplicationController
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_course_admin
 
   def toggle_allow_extended_requests
     @enrollment = @course.user_to_courses.find(params[:id])
+    authorize @enrollment
 
     if @enrollment.update(allow_extended_requests: params[:allow_extended_requests])
       render json: { success: true }, status: :ok
@@ -12,14 +12,5 @@ class UserToCoursesController < ApplicationController
       flash[:alert] = "Failed to update enrollment: #{@enrollment.errors.full_messages.to_sentence}"
       render json: { redirect_to: course_path(@course) }, status: :unprocessable_content
     end
-  end
-
-  private
-
-  def ensure_course_admin
-    enrollment = @course.user_to_courses.find_by(user: @user)
-    return if enrollment&.course_admin?
-
-    render json: { error: 'You must be an instructor or Lead TA.', redirect_to: course_path(@course) }, status: :forbidden
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -66,7 +66,7 @@ class Course < ApplicationRecord
   # Or is user.staff_role?(course) or user.student_role?(course) better?
   def user_role(user)
     roles = UserToCourse.where(user_id: user.id, course_id: id).pluck(:role)
-    return 'instructor' if roles.include?('teacher') || roles.include?('ta')
+    return 'instructor' if roles.include?('teacher') || roles.include?('ta') || roles.include?('leadta')
     return 'student' if roles.include?('student')
 
     nil

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,42 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  private
+
+  def site_admin?
+    user&.admin?
+  end
+end

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -1,0 +1,22 @@
+class AssignmentPolicy < ApplicationPolicy
+  # record is an Assignment
+
+  # Only course admins (teacher/leadta) can toggle assignment enabled status
+  def toggle_enabled?
+    course_admin? || site_admin?
+  end
+
+  private
+
+  def course
+    record.course_to_lms.course
+  end
+
+  def enrollment
+    @enrollment ||= UserToCourse.find_by(user: user, course_id: course.id)
+  end
+
+  def course_admin?
+    enrollment&.course_admin? || false
+  end
+end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -1,0 +1,62 @@
+class CoursePolicy < ApplicationPolicy
+  # record is a Course
+
+  # Anyone enrolled or site admin can see the course list
+  def index?
+    user.present?
+  end
+
+  def show?
+    enrolled? || site_admin?
+  end
+
+  # Everyone can view the import course page
+  def new?
+    user.present?
+  end
+
+  # Any TA/instructor can create (import) a course
+  def create?
+    user.present?
+  end
+
+  # Only course admins (teacher/leadta) and site admins
+  def edit?
+    course_admin? || site_admin?
+  end
+
+  def enrollments?
+    staff? || site_admin?
+  end
+
+  def delete?
+    course_admin? || site_admin?
+  end
+
+  # TAs can sync assignments and enrollments
+  def sync_assignments?
+    staff? || site_admin?
+  end
+
+  def sync_enrollments?
+    staff? || site_admin?
+  end
+
+  private
+
+  def enrollment
+    @enrollment ||= UserToCourse.find_by(user: user, course_id: record.id)
+  end
+
+  def enrolled?
+    enrollment.present?
+  end
+
+  def course_admin?
+    enrollment&.course_admin? || false
+  end
+
+  def staff?
+    enrollment&.staff? || false
+  end
+end

--- a/app/policies/course_settings_policy.rb
+++ b/app/policies/course_settings_policy.rb
@@ -1,0 +1,22 @@
+class CourseSettingsPolicy < ApplicationPolicy
+  # record is a CourseSettings
+
+  # Only course admins (teacher/leadta) can update settings
+  def update?
+    course_admin? || site_admin?
+  end
+
+  private
+
+  def course
+    record.is_a?(Course) ? record : record.course
+  end
+
+  def enrollment
+    @enrollment ||= UserToCourse.find_by(user: user, course_id: course.id)
+  end
+
+  def course_admin?
+    enrollment&.course_admin? || false
+  end
+end

--- a/app/policies/form_setting_policy.rb
+++ b/app/policies/form_setting_policy.rb
@@ -1,0 +1,26 @@
+class FormSettingPolicy < ApplicationPolicy
+  # record is a FormSetting
+
+  # Only course admins (teacher/leadta) can edit/update form settings
+  def edit?
+    course_admin? || site_admin?
+  end
+
+  def update?
+    course_admin? || site_admin?
+  end
+
+  private
+
+  def course
+    record.is_a?(Course) ? record : record.course
+  end
+
+  def enrollment
+    @enrollment ||= UserToCourse.find_by(user: user, course_id: course.id)
+  end
+
+  def course_admin?
+    enrollment&.course_admin? || false
+  end
+end

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -1,0 +1,83 @@
+class RequestPolicy < ApplicationPolicy
+  # record is a Request
+
+  def index?
+    enrolled? || site_admin?
+  end
+
+  def show?
+    staff? || owner? || site_admin?
+  end
+
+  def new?
+    enrolled? || site_admin?
+  end
+
+  def create?
+    enrolled? || site_admin?
+  end
+
+  def edit?
+    owner? || site_admin?
+  end
+
+  def update?
+    owner? || site_admin?
+  end
+
+  def cancel?
+    owner? || staff? || site_admin?
+  end
+
+  # Only staff (all TAs + teachers) can approve/reject
+  def approve?
+    staff? || site_admin?
+  end
+
+  def reject?
+    staff? || site_admin?
+  end
+
+  def mass_approve?
+    staff? || site_admin?
+  end
+
+  def mass_reject?
+    staff? || site_admin?
+  end
+
+  # Staff can create requests on behalf of students
+  def create_for_student?
+    staff? || site_admin?
+  end
+
+  def new_for_student?
+    staff? || site_admin?
+  end
+
+  private
+
+  def course
+    record.is_a?(Course) ? record : record.course
+  end
+
+  def enrollment
+    @enrollment ||= UserToCourse.find_by(user: user, course_id: course.id)
+  end
+
+  def enrolled?
+    enrollment.present?
+  end
+
+  def course_admin?
+    enrollment&.course_admin? || false
+  end
+
+  def staff?
+    enrollment&.staff? || false
+  end
+
+  def owner?
+    record.respond_to?(:user_id) && record.user_id == user&.id
+  end
+end

--- a/app/policies/user_to_course_policy.rb
+++ b/app/policies/user_to_course_policy.rb
@@ -1,0 +1,18 @@
+class UserToCoursePolicy < ApplicationPolicy
+  # record is a UserToCourse (enrollment)
+
+  # Only course admins (teacher/leadta) can toggle extended circumstances
+  def toggle_allow_extended_requests?
+    course_admin? || site_admin?
+  end
+
+  private
+
+  def enrollment
+    @enrollment ||= UserToCourse.find_by(user: user, course_id: record.course_id)
+  end
+
+  def course_admin?
+    enrollment&.course_admin? || false
+  end
+end

--- a/spec/factories/user_to_course.rb
+++ b/spec/factories/user_to_course.rb
@@ -8,6 +8,14 @@ FactoryBot.define do
       role { 'teacher' }
     end
 
+    trait :as_leadta do
+      role { 'leadta' }
+    end
+
+    trait :as_ta do
+      role { 'ta' }
+    end
+
     trait :as_student do
       role { 'student' }
     end

--- a/spec/policies/assignment_policy_spec.rb
+++ b/spec/policies/assignment_policy_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe AssignmentPolicy do
+  subject { described_class.new(user, assignment) }
+
+  let(:course) { create(:course) }
+  let(:assignment) { course.assignments.first }
+
+  context 'when user is a site admin' do
+    let(:user) { create(:admin) }
+
+    it { is_expected.to permit_action(:toggle_enabled) }
+  end
+
+  context 'when user is a teacher (course admin)' do
+    let(:user) { create(:user_to_course, :as_teacher, course: course).user }
+
+    it { is_expected.to permit_action(:toggle_enabled) }
+  end
+
+  context 'when user is a lead TA (course admin)' do
+    let(:user) { create(:user_to_course, :as_leadta, course: course).user }
+
+    it { is_expected.to permit_action(:toggle_enabled) }
+  end
+
+  context 'when user is a regular TA' do
+    let(:user) { create(:user_to_course, :as_ta, course: course).user }
+
+    it { is_expected.not_to permit_action(:toggle_enabled) }
+  end
+
+  context 'when user is a student' do
+    let(:user) { create(:user_to_course, :as_student, course: course).user }
+
+    it { is_expected.not_to permit_action(:toggle_enabled) }
+  end
+end

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe CoursePolicy do
+  subject { described_class.new(user, course) }
+
+  let(:course) { create(:course) }
+
+  let(:teacher_enrollment) { create(:user_to_course, :as_teacher, course: course) }
+  let(:leadta_enrollment) { create(:user_to_course, :as_leadta, course: course) }
+  let(:ta_enrollment) { create(:user_to_course, :as_ta, course: course) }
+  let(:student_enrollment) { create(:user_to_course, :as_student, course: course) }
+
+  context 'when user is a site admin' do
+    let(:user) { create(:admin) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:enrollments) }
+    it { is_expected.to permit_action(:delete) }
+    it { is_expected.to permit_action(:sync_assignments) }
+    it { is_expected.to permit_action(:sync_enrollments) }
+  end
+
+  context 'when user is a teacher (course admin)' do
+    let(:user) { teacher_enrollment.user }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:enrollments) }
+    it { is_expected.to permit_action(:delete) }
+    it { is_expected.to permit_action(:sync_assignments) }
+    it { is_expected.to permit_action(:sync_enrollments) }
+  end
+
+  context 'when user is a lead TA (course admin)' do
+    let(:user) { leadta_enrollment.user }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:enrollments) }
+    it { is_expected.to permit_action(:delete) }
+    it { is_expected.to permit_action(:sync_assignments) }
+    it { is_expected.to permit_action(:sync_enrollments) }
+  end
+
+  context 'when user is a regular TA' do
+    let(:user) { ta_enrollment.user }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.to permit_action(:enrollments) }
+    it { is_expected.not_to permit_action(:delete) }
+    it { is_expected.to permit_action(:sync_assignments) }
+    it { is_expected.to permit_action(:sync_enrollments) }
+  end
+
+  context 'when user is a student' do
+    let(:user) { student_enrollment.user }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:enrollments) }
+    it { is_expected.not_to permit_action(:delete) }
+    it { is_expected.not_to permit_action(:sync_assignments) }
+    it { is_expected.not_to permit_action(:sync_enrollments) }
+  end
+
+  context 'when user is not enrolled' do
+    let(:user) { create(:user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.not_to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:enrollments) }
+    it { is_expected.not_to permit_action(:delete) }
+    it { is_expected.not_to permit_action(:sync_assignments) }
+    it { is_expected.not_to permit_action(:sync_enrollments) }
+  end
+end

--- a/spec/policies/course_settings_policy_spec.rb
+++ b/spec/policies/course_settings_policy_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CourseSettingsPolicy do
+  subject { described_class.new(user, course.course_settings) }
+
+  let(:course) { create(:course) }
+
+  context 'when user is a site admin' do
+    let(:user) { create(:admin) }
+
+    it { is_expected.to permit_action(:update) }
+  end
+
+  context 'when user is a teacher (course admin)' do
+    let(:user) { create(:user_to_course, :as_teacher, course: course).user }
+
+    it { is_expected.to permit_action(:update) }
+  end
+
+  context 'when user is a lead TA (course admin)' do
+    let(:user) { create(:user_to_course, :as_leadta, course: course).user }
+
+    it { is_expected.to permit_action(:update) }
+  end
+
+  context 'when user is a regular TA' do
+    let(:user) { create(:user_to_course, :as_ta, course: course).user }
+
+    it { is_expected.not_to permit_action(:update) }
+  end
+
+  context 'when user is a student' do
+    let(:user) { create(:user_to_course, :as_student, course: course).user }
+
+    it { is_expected.not_to permit_action(:update) }
+  end
+end

--- a/spec/policies/form_setting_policy_spec.rb
+++ b/spec/policies/form_setting_policy_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe FormSettingPolicy do
+  subject { described_class.new(user, course.form_setting) }
+
+  let(:course) { create(:course) }
+
+  context 'when user is a site admin' do
+    let(:user) { create(:admin) }
+
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+  end
+
+  context 'when user is a teacher (course admin)' do
+    let(:user) { create(:user_to_course, :as_teacher, course: course).user }
+
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+  end
+
+  context 'when user is a lead TA (course admin)' do
+    let(:user) { create(:user_to_course, :as_leadta, course: course).user }
+
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+  end
+
+  context 'when user is a regular TA' do
+    let(:user) { create(:user_to_course, :as_ta, course: course).user }
+
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:update) }
+  end
+
+  context 'when user is a student' do
+    let(:user) { create(:user_to_course, :as_student, course: course).user }
+
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:update) }
+  end
+end

--- a/spec/policies/request_policy_spec.rb
+++ b/spec/policies/request_policy_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe RequestPolicy do
+  let(:course) { create(:course) }
+  let(:assignment) { course.assignments.first }
+
+  let(:teacher_enrollment) { create(:user_to_course, :as_teacher, course: course) }
+  let(:leadta_enrollment) { create(:user_to_course, :as_leadta, course: course) }
+  let(:ta_enrollment) { create(:user_to_course, :as_ta, course: course) }
+  let(:student_enrollment) { create(:user_to_course, :as_student, course: course) }
+
+  let(:student_user) { student_enrollment.user }
+  let(:request_record) { create(:request, course: course, user: student_user, assignment: assignment) }
+
+  context 'when user is a site admin' do
+    subject { described_class.new(create(:admin), request_record) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:cancel) }
+    it { is_expected.to permit_action(:approve) }
+    it { is_expected.to permit_action(:reject) }
+    it { is_expected.to permit_action(:mass_approve) }
+    it { is_expected.to permit_action(:mass_reject) }
+    it { is_expected.to permit_action(:create_for_student) }
+    it { is_expected.to permit_action(:new_for_student) }
+  end
+
+  context 'when user is a teacher' do
+    subject { described_class.new(teacher_enrollment.user, request_record) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:update) }
+    it { is_expected.to permit_action(:cancel) }
+    it { is_expected.to permit_action(:approve) }
+    it { is_expected.to permit_action(:reject) }
+    it { is_expected.to permit_action(:mass_approve) }
+    it { is_expected.to permit_action(:mass_reject) }
+    it { is_expected.to permit_action(:create_for_student) }
+    it { is_expected.to permit_action(:new_for_student) }
+  end
+
+  context 'when user is a lead TA' do
+    subject { described_class.new(leadta_enrollment.user, request_record) }
+
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:approve) }
+    it { is_expected.to permit_action(:reject) }
+    it { is_expected.to permit_action(:create_for_student) }
+    it { is_expected.to permit_action(:new_for_student) }
+  end
+
+  context 'when user is a regular TA' do
+    subject { described_class.new(ta_enrollment.user, request_record) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:update) }
+    it { is_expected.to permit_action(:cancel) }
+    it { is_expected.to permit_action(:approve) }
+    it { is_expected.to permit_action(:reject) }
+    it { is_expected.to permit_action(:mass_approve) }
+    it { is_expected.to permit_action(:mass_reject) }
+    it { is_expected.to permit_action(:create_for_student) }
+    it { is_expected.to permit_action(:new_for_student) }
+  end
+
+  context 'when user is the request owner (student)' do
+    subject { described_class.new(student_user, request_record) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:cancel) }
+    it { is_expected.not_to permit_action(:approve) }
+    it { is_expected.not_to permit_action(:reject) }
+    it { is_expected.not_to permit_action(:mass_approve) }
+    it { is_expected.not_to permit_action(:mass_reject) }
+    it { is_expected.not_to permit_action(:create_for_student) }
+    it { is_expected.not_to permit_action(:new_for_student) }
+  end
+
+  context 'when user is a different student (not owner)' do
+    let(:other_student) { create(:user_to_course, :as_student, course: course).user }
+
+    subject { described_class.new(other_student, request_record) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.not_to permit_action(:show) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:update) }
+    it { is_expected.not_to permit_action(:cancel) }
+    it { is_expected.not_to permit_action(:approve) }
+    it { is_expected.not_to permit_action(:reject) }
+  end
+end

--- a/spec/policies/user_to_course_policy_spec.rb
+++ b/spec/policies/user_to_course_policy_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe UserToCoursePolicy do
+  subject { described_class.new(user, target_enrollment) }
+
+  let(:course) { create(:course) }
+  let(:target_enrollment) { create(:user_to_course, :as_student, course: course) }
+
+  context 'when user is a site admin' do
+    let(:user) { create(:admin) }
+
+    it { is_expected.to permit_action(:toggle_allow_extended_requests) }
+  end
+
+  context 'when user is a teacher (course admin)' do
+    let(:user) { create(:user_to_course, :as_teacher, course: course).user }
+
+    it { is_expected.to permit_action(:toggle_allow_extended_requests) }
+  end
+
+  context 'when user is a lead TA (course admin)' do
+    let(:user) { create(:user_to_course, :as_leadta, course: course).user }
+
+    it { is_expected.to permit_action(:toggle_allow_extended_requests) }
+  end
+
+  context 'when user is a regular TA' do
+    let(:user) { create(:user_to_course, :as_ta, course: course).user }
+
+    it { is_expected.not_to permit_action(:toggle_allow_extended_requests) }
+  end
+
+  context 'when user is a student' do
+    let(:user) { create(:user_to_course, :as_student, course: course).user }
+
+    it { is_expected.not_to permit_action(:toggle_allow_extended_requests) }
+  end
+end


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

This PR replaces the existing ad-hoc role-checking logic scattered across controllers with a centralized, policy-based authorization system using the [Pundit](https://github.com/varvet/pundit) gem.

## Why

The previous approach used manual `@role == 'instructor'` checks and custom `before_action` guard methods in individual controllers. This was inconsistent, hard to test in isolation, and didn't correctly handle the `leadta` role (lead TAs were silently denied access to actions they should have been permitted to perform due to a bug in `Course#user_role`).

## What Changed

### Bug Fix
- `Course#user_role` now correctly maps `leadta` to `'instructor'`, fixing a regression where lead TAs were denied all access.

### Authorization Architecture
- Added `pundit` gem and `pundit-matchers` for testing
- Included `Pundit::Authorization` in `ApplicationController` with a centralized `rescue_from Pundit::NotAuthorizedError` handler
- Created 6 policy classes (`CoursePolicy`, `RequestPolicy`, `CourseSettingsPolicy`, `FormSettingPolicy`, `AssignmentPolicy`, `UserToCoursePolicy`) with an `ApplicationPolicy` base

### Controller Refactoring
- Removed custom `before_action` guards (`ensure_instructor_role`, `check_instructor_permission`, `ensure_course_admin`) from `CourseSettingsController`, `FormSettingsController`, `RequestsController`, and `UserToCoursesController`
- Replaced inline role checks with `authorize` calls in `CoursesController`, `AssignmentsController`, and `RequestsController`
- Fixed `CoursesController#index` to include `leadta` in the staff courses query

### Permissions Matrix

| Action | Site Admin | Teacher | Lead TA | Regular TA | Student |
|--------|:---------:|:-------:|:-------:|:----------:|:-------:|
| View/import course page | ✅ | ✅ | ✅ | ✅ | ✅ |
| View course | ✅ | ✅ | ✅ | ✅ | Own only |
| Edit course settings | ✅ | ✅ | ✅ | ❌ | ❌ |
| Delete course | ✅ | ✅ | ✅ | ❌ | ❌ |
| View enrollments | ✅ | ✅ | ✅ | ✅ | ❌ |
| Toggle extended circumstances | ✅ | ✅ | ✅ | ❌ | ❌ |
| Sync assignments/enrollments | ✅ | ✅ | ✅ | ✅ | ❌ |
| Approve/reject requests | ✅ | ✅ | ✅ | ✅ | ❌ |
| Toggle assignment enabled | ✅ | ✅ | ✅ | ❌ | ❌ |
| Edit form settings | ✅ | ✅ | ✅ | ❌ | ❌ |
| Manage own requests | ✅ | — | — | — | ✅ |

# Testing

Added comprehensive policy specs in `spec/policies/` covering all user roles (site admin, teacher, lead TA, regular TA, student, unenrolled) for every policy action using `pundit-matchers`. Also added `:as_leadta` and `:as_ta` factory traits to `spec/factories/user_to_course.rb` to support the new specs.

Existing controller specs should continue to pass as the authorization behavior is preserved — only the implementation mechanism has changed.

# Documentation

No external documentation required. The policy classes are self-documenting and the permissions matrix above captures the intended behavior.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/tb8BdQdTgPTj/implementations/CKg9Jnf9gwtM) | [App Preview](https://www.superconductor.com/tickets/tb8BdQdTgPTj/implementations/CKg9Jnf9gwtM/preview) | [Guided Review](https://www.superconductor.com/tickets/tb8BdQdTgPTj/implementations/CKg9Jnf9gwtM?tab=guided_review)

<!-- created-by-superconductor -->