### PR TITLE
Refactor permissions logic with cancancan gem and define Abilities for user roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'omniauth'
 gem 'omniauth-canvas'
 gem 'omniauth-oauth2'
 
+# Authorization
+gem 'cancancan'
+
 # Audit for potentially unsafe database migrations
 gem 'strong_migrations'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
     brakeman (8.0.4)
       racc
     builder (3.3.0)
+    cancancan (3.6.1)
     capybara (3.40.0)
       addressable
       matrix
@@ -619,6 +620,7 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 5.3.8)
   brakeman
+  cancancan
   capybara-screenshot
   codeclimate-test-reporter
   cucumber-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticated!, unless: -> { excluded_controller_action? }
 
   rescue_from LmsFacade::LmsAPIError, with: :handle_lms_api_error
+  rescue_from CanCan::AccessDenied, with: :handle_access_denied
 
   def excluded_controller_action?
     # Actions and controllers that do NOT require authentication
@@ -77,6 +78,18 @@ class ApplicationController < ActionController::Base
     redirect_back_or_to(root_path)
   end
 
+  def handle_access_denied(exception)
+    respond_to do |format|
+      format.html do
+        flash[:alert] = exception.message || 'You are not authorized to perform this action.'
+        redirect_to courses_path
+      end
+      format.json do
+        render json: { error: exception.message || 'You are not authorized to perform this action.' }, status: :forbidden
+      end
+    end
+  end
+
   def set_pending_request_count
     return unless defined?(@course) && @course.present? && defined?(@user) && @user.present?
     # only calculating pending requests count if the role is instructor so we don't show it to students
@@ -122,9 +135,6 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_instructor_role
-    return if @role == 'instructor'
-
-    flash[:alert] = 'You do not have access to this page.'
-    redirect_to courses_path
+    authorize! :update, @course
   end
 end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,18 +1,12 @@
 class AssignmentsController < ApplicationController
   def toggle_enabled
     @assignment = Assignment.find(params[:id])
-    course = @assignment.course_to_lms.course
-    @role = params[:role] || course&.user_role(@user)
-
-    unless @role == 'instructor'
-      Rails.logger.error "Role #{@role} does not have permission to toggle assignment enabled status"
-      flash.now[:alert] = 'You do not have permission to perform this action.'
-      return render json: { redirect_to: course_path(course) }, status: :forbidden
-    end
+    authorize! :toggle_enabled, @assignment
 
     if @assignment.update(enabled: params[:enabled])
       render json: { success: true }, status: :ok
     else
+      course = @assignment.course_to_lms.course
       flash[:alert] = "Failed to update assignment: #{@assignment.errors.full_messages.to_sentence}"
       render json: { redirect_to: course_path(course) }, status: :unprocessable_content
     end

--- a/app/controllers/course_settings_controller.rb
+++ b/app/controllers/course_settings_controller.rb
@@ -2,7 +2,7 @@ class CourseSettingsController < ApplicationController
   before_action :authenticated!
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_instructor_role
+  before_action :authorize_course_settings
   before_action :set_pending_request_count
 
   # Default template settings
@@ -74,6 +74,11 @@ class CourseSettingsController < ApplicationController
       :enable_slack_webhook_url,
       :slack_webhook_url
     )
+  end
+
+  def authorize_course_settings
+    course_settings = @course.course_settings || @course.build_course_settings
+    authorize! :update, course_settings
   end
 
   def set_pending_request_count

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,7 +5,7 @@ class CoursesController < ApplicationController
   before_action :determine_user_role
 
   def index
-    @teacher_courses = UserToCourse.includes(:course).where(user: @user, role: %w[teacher ta])
+    @teacher_courses = UserToCourse.includes(:course).where(user: @user, role: UserToCourse.staff_roles)
 
     # Only show courses to students if extensions are enabled at the course level
     student_courses = UserToCourse.includes(course: :course_settings).where(user: @user, role: 'student')
@@ -19,6 +19,7 @@ class CoursesController < ApplicationController
     return redirect_to courses_path, alert: 'Course not found.' unless @course
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless @course.has_canvas_linked?
 
+    authorize! :read, @course
     @side_nav = 'show'
     @course.regenerate_readonly_api_token_if_blank
 
@@ -34,6 +35,7 @@ class CoursesController < ApplicationController
   end
 
   def new
+    authorize! :import, Course
     token = @user.lms_credentials.first.token
     @courses = Course.fetch_courses(token)
     flash[:alert] = 'No courses found.' if @courses.empty?
@@ -56,11 +58,12 @@ class CoursesController < ApplicationController
   end
 
   def edit
+    authorize! :update, @course
     @side_nav = 'edit'
-    redirect_to course_path(@course.id), alert: 'You do not have access to this page.' unless @role == 'instructor'
   end
 
   def create
+    authorize! :create, Course
     token = @user.lms_credentials.first.token
     filter_courses(Course.fetch_courses(token), %w[teacher ta])
       .select { |c| params[:courses]&.include?(c['id'].to_s) }
@@ -71,6 +74,7 @@ class CoursesController < ApplicationController
   def sync_assignments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
 
+    authorize! :sync_assignments, @course
     @course.sync_assignments(@user)
     render json: { message: 'Assignments synced successfully.' }, status: :ok
   end
@@ -78,20 +82,21 @@ class CoursesController < ApplicationController
   def sync_enrollments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
 
+    authorize! :sync_enrollments, @course
     @course.sync_all_enrollments_from_canvas(@user.id)
     render json: { message: 'Users synced successfully.' }, status: :ok
   end
 
   def enrollments
+    authorize! :enrollments, @course
     @side_nav = 'enrollments'
-    return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
 
     @enrollments = @course.user_to_courses.includes(:user)
     @is_course_admin = @course.user_to_courses.find_by(user: @user)&.course_admin?
   end
 
   def delete
-    return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
+    authorize! :destroy, @course
     return redirect_to courses_path, alert: 'Extensions are enabled for this course.' if @course.course_settings&.enable_extensions
 
     assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: @course.id).select(:id))

--- a/app/controllers/form_settings_controller.rb
+++ b/app/controllers/form_settings_controller.rb
@@ -2,7 +2,7 @@ class FormSettingsController < ApplicationController
   before_action :authenticated!
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_instructor_role
+  before_action :authorize_form_settings
   before_action :set_pending_request_count
 
   def edit
@@ -42,6 +42,11 @@ class FormSettingsController < ApplicationController
       :custom_q1, :custom_q1_desc, :custom_q1_disp,
       :custom_q2, :custom_q2_desc, :custom_q2_disp
     )
+  end
+
+  def authorize_form_settings
+    form_setting = @course.form_setting || @course.build_form_setting
+    authorize! :update, form_setting
   end
 
   def set_pending_request_count

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -11,7 +11,6 @@ class RequestsController < ApplicationController
   before_action :check_extensions_enabled_for_students, except: [ :export ]
   before_action :ensure_request_is_pending, only: %i[update approve reject]
   before_action :set_request, only: %i[show edit cancel]
-  before_action :check_instructor_permission, only: %i[approve reject mass_approve mass_reject]
 
   def index
     @side_nav = 'requests'
@@ -42,9 +41,11 @@ class RequestsController < ApplicationController
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
 
     if @role == 'instructor'
+      authorize! :create_for_student, Request.new(course: @course)
       prepare_instructor_new_request(course_to_lmss)
       render :new_for_student and return
     elsif @role == 'student'
+      authorize! :create, Request.new(course: @course, user: @user)
       redirected = prepare_student_new_request(course_to_lmss)
       return if redirected
 
@@ -56,7 +57,7 @@ class RequestsController < ApplicationController
 
   def new_for_student
     @side_nav = 'form'
-    return redirect_to course_requests_path(@course), alert: 'You do not have permission to access this page.' unless @role == 'instructor'
+    authorize! :create_for_student, Request.new(course: @course)
 
     course_to_lmss = @course.all_linked_lmss.pluck(:id)
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
@@ -91,7 +92,7 @@ class RequestsController < ApplicationController
   end
 
   def create_for_student
-    return redirect_to course_requests_path(@course), alert: 'You do not have permission to perform this action.' unless @role == 'instructor'
+    authorize! :create_for_student, Request.new(course: @course)
 
     student = User.find_by(id: params[:request][:user_id])
     return redirect_to new_course_request_path(@course), alert: 'Student not found.' unless student
@@ -114,6 +115,8 @@ class RequestsController < ApplicationController
     @request = @course.requests.find_by(id: params[:id])
     return redirect_to course_path(@course), alert: 'Request not found.' unless @request
 
+    authorize! :update, @request
+
     Request.merge_date_and_time!(params[:request])
 
     if @request.update(request_params)
@@ -126,6 +129,7 @@ class RequestsController < ApplicationController
   end
 
   def cancel
+    authorize! :cancel, @request
     if @request.reject(@user)
       redirect_to course_requests_path(@course), notice: 'Request canceled successfully.'
     else
@@ -134,6 +138,7 @@ class RequestsController < ApplicationController
   end
 
   def approve
+    authorize! :approve, @request
     @assignment = Assignment.find_by(id: @request.assignment_id)
     lms_facade = @assignment.lms_facade
     if @request.approve(lms_facade.from_user(@user), @user)
@@ -152,6 +157,7 @@ class RequestsController < ApplicationController
   end
 
   def reject
+    authorize! :reject, @request
     if @request.reject(@user)
       notice = 'Request denied successfully.'
       respond_to do |format|
@@ -168,10 +174,12 @@ class RequestsController < ApplicationController
   end
 
   def mass_approve
+    authorize! :approve, Request.new(course: @course)
     process_mass_action(:approve)
   end
 
   def mass_reject
+    authorize! :reject, Request.new(course: @course)
     process_mass_action(:reject)
   end
 
@@ -194,11 +202,6 @@ class RequestsController < ApplicationController
     @side_nav = 'requests'
     @request = @course.requests.includes(:assignment).find_by(id: params[:id])
     redirect_to course_path(@course), alert: 'Request not found.' unless @request
-  end
-
-  def check_instructor_permission
-    result = RequestService.check_instructor_permission(@role, course_path(@course))
-    redirect_to result[:redirect_to], alert: result[:alert] if result != true
   end
 
   def handle_request_error

--- a/app/controllers/user_to_courses_controller.rb
+++ b/app/controllers/user_to_courses_controller.rb
@@ -1,10 +1,10 @@
 class UserToCoursesController < ApplicationController
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_course_admin
 
   def toggle_allow_extended_requests
     @enrollment = @course.user_to_courses.find(params[:id])
+    authorize! :toggle_allow_extended_requests, @enrollment
 
     if @enrollment.update(allow_extended_requests: params[:allow_extended_requests])
       render json: { success: true }, status: :ok
@@ -12,14 +12,5 @@ class UserToCoursesController < ApplicationController
       flash[:alert] = "Failed to update enrollment: #{@enrollment.errors.full_messages.to_sentence}"
       render json: { redirect_to: course_path(@course) }, status: :unprocessable_content
     end
-  end
-
-  private
-
-  def ensure_course_admin
-    enrollment = @course.user_to_courses.find_by(user: @user)
-    return if enrollment&.course_admin?
-
-    render json: { error: 'You must be an instructor or Lead TA.', redirect_to: course_path(@course) }, status: :forbidden
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    return unless user
+
+    # All logged-in users can view the course import page
+    can :import, Course
+
+    # Site admins can do everything
+    if user.admin?
+      can :manage, :all
+      return
+    end
+
+    # Any staff member (in any course) can create/import courses
+    can :create, Course if user.user_to_courses.where(role: UserToCourse.staff_roles).exists?
+
+    # Course-specific permissions based on enrollments
+    user.user_to_courses.where(removed: false).find_each do |enrollment|
+      case enrollment.role
+      when 'teacher', 'leadta'
+        grant_course_admin_abilities(enrollment.course_id)
+      when 'ta'
+        grant_ta_abilities(enrollment.course_id)
+      when 'student'
+        grant_student_abilities(user.id, enrollment.course_id)
+      end
+    end
+  end
+
+  private
+
+  # Course admins (instructors and lead TAs) can manage everything in their course
+  def grant_course_admin_abilities(course_id)
+    can :manage, Course, id: course_id
+    can :manage, Request, course_id: course_id
+    can :manage, Assignment, course_to_lms: { course_id: course_id }
+    can :manage, CourseSettings, course_id: course_id
+    can :manage, FormSetting, course_id: course_id
+    can :manage, UserToCourse, course_id: course_id
+  end
+
+  # Regular TAs can view everything, approve/deny requests, and sync.
+  # They cannot update settings or toggle extended circumstances.
+  def grant_ta_abilities(course_id)
+    can :read, Course, id: course_id
+    can [:sync_assignments, :sync_enrollments, :enrollments], Course, id: course_id
+
+    can [:read, :create, :approve, :reject, :create_for_student, :export], Request, course_id: course_id
+
+    can [:read, :toggle_enabled], Assignment, course_to_lms: { course_id: course_id }
+
+    can :read, CourseSettings, course_id: course_id
+    can :read, FormSetting, course_id: course_id
+    can :read, UserToCourse, course_id: course_id
+  end
+
+  # Students can only manage their own requests within a course
+  def grant_student_abilities(user_id, course_id)
+    can :read, Course, id: course_id
+
+    can [:read, :create, :update, :cancel], Request, course_id: course_id, user_id: user_id
+
+    can :read, Assignment, course_to_lms: { course_id: course_id }
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -66,7 +66,7 @@ class Course < ApplicationRecord
   # Or is user.staff_role?(course) or user.student_role?(course) better?
   def user_role(user)
     roles = UserToCourse.where(user_id: user.id, course_id: id).pluck(:role)
-    return 'instructor' if roles.include?('teacher') || roles.include?('ta')
+    return 'instructor' if (roles & UserToCourse.staff_roles).any?
     return 'student' if roles.include?('student')
 
     nil

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -2,12 +2,8 @@
 require 'rails_helper'
 
 RSpec.describe AssignmentsController, type: :controller do
-  before do
-    session[:user_id] = '123'
-  end
-
   describe 'POST #toggle_enabled' do
-    let!(:user) { User.create!(name: 'Test User', email: 'test@example.com') }
+    let!(:user) { User.create!(name: 'Test User', email: 'test@example.com', canvas_uid: '123') }
     let!(:course) { Course.create!(course_name: 'Test Course', canvas_id: '123') }
     let!(:course_to_lms) { CourseToLms.create!(course: course, lms_id: 1, external_course_id: '123') }
     let!(:course_settings) { CourseSettings.create!(course: course, enable_extensions: true) }
@@ -21,13 +17,23 @@ RSpec.describe AssignmentsController, type: :controller do
       )
     end
 
+    before do
+      session[:user_id] = '123'
+      user.lms_credentials.create!(
+        lms_name: 'canvas',
+        token: 'fake_token',
+        refresh_token: 'fake_refresh_token',
+        expire_time: 1.hour.from_now
+      )
+    end
+
     context 'when the user is an instructor' do
       before do
-        allow(course).to receive(:user_role).with(user).and_return('instructor')
+        UserToCourse.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'updates the enabled status to true' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:ok)
         expect(assignment.reload.enabled).to be true
@@ -36,7 +42,7 @@ RSpec.describe AssignmentsController, type: :controller do
       it 'updates the enabled status to false' do
         assignment.update!(enabled: true)
 
-        post :toggle_enabled, params: { id: assignment.id, enabled: false, role: 'instructor', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: false }
 
         expect(response).to have_http_status(:ok)
         expect(assignment.reload.enabled).to be false
@@ -45,13 +51,13 @@ RSpec.describe AssignmentsController, type: :controller do
 
     context 'when the user is not an instructor' do
       before do
-        allow(course).to receive(:user_role).with(user).and_return('student')
+        UserToCourse.create!(user: user, course: course, role: 'student')
       end
 
-      it 'returns a forbidden status' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'student', user_id: user.id }
+      it 'denies access' do
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to redirect_to(courses_path)
         expect(assignment.reload.enabled).to be false
       end
     end
@@ -59,11 +65,11 @@ RSpec.describe AssignmentsController, type: :controller do
     context 'when course-level extensions are disabled' do
       before do
         course_settings.update!(enable_extensions: false)
-        allow(course).to receive(:user_role).with(user).and_return('instructor')
+        UserToCourse.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'still allows enabling the assignment and returns ok status' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:ok)
         expect(assignment.reload.enabled).to be true
@@ -73,23 +79,24 @@ RSpec.describe AssignmentsController, type: :controller do
     context 'when there is no due_date on an Assignment' do
       before do
         assignment.update!(due_date: nil)
+        UserToCourse.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'returns a bad request status' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(flash[:alert]).to include('Due date must be present if assignment is enabled')
       end
     end
 
-    context 'when user_id is not provided' do
+    context 'when the user is a TA' do
       before do
-        allow(course).to receive(:user_role).and_return('instructor')
+        UserToCourse.create!(user: user, course: course, role: 'ta')
       end
 
       it 'uses the session user and updates the assignment' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor' }
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:ok)
         expect(assignment.reload.enabled).to be true

--- a/spec/controllers/course_settings_controller_spec.rb
+++ b/spec/controllers/course_settings_controller_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe CourseSettingsController, type: :controller do
   describe 'instructor access' do
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
-      allow_any_instance_of(Course).to receive(:user_role).with(instructor).and_return('instructor')
+      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
     end
 
     describe 'POST #update' do
@@ -134,8 +133,7 @@ RSpec.describe CourseSettingsController, type: :controller do
 
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
-      allow_any_instance_of(Course).to receive(:user_role).with(instructor).and_return('instructor')
+      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
 
       # Create settings to enable extensions
       CourseSettings.create!(
@@ -196,7 +194,6 @@ RSpec.describe CourseSettingsController, type: :controller do
         expire_time: 1.hour.from_now
       )
       UserToCourse.create!(user: student, course: course, role: 'student')
-      allow_any_instance_of(Course).to receive(:user_role).with(student).and_return('student')
 
       # Create some course settings to attempt to modify
       CourseSettings.create!(
@@ -217,7 +214,7 @@ RSpec.describe CourseSettingsController, type: :controller do
       }
 
       expect(response).to redirect_to(courses_path)
-      expect(flash[:alert]).to eq('You do not have access to this page.')
+      expect(flash[:alert]).to be_present
 
       # Verify settings were not changed
       expect(course.reload.course_settings.enable_extensions).to be false
@@ -232,7 +229,7 @@ RSpec.describe CourseSettingsController, type: :controller do
       }
 
       expect(response).to redirect_to(courses_path)
-      expect(flash[:alert]).to eq('You do not have access to this page.')
+      expect(flash[:alert]).to be_present
     end
   end
 
@@ -252,7 +249,7 @@ RSpec.describe CourseSettingsController, type: :controller do
 
     it 'redirects to courses path when course is not found' do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
+      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
 
       post :update, params: {
         course_id: 999,

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -60,12 +60,25 @@ RSpec.describe CoursesController, type: :controller do
   describe 'GET #edit' do
     it 'redirects non-instructor users' do
       get :edit, params: { id: course.id }
-      expect(response).to redirect_to(course_path(course))
-      expect(flash[:alert]).to eq('You do not have access to this page.')
+      expect(response).to redirect_to(courses_path)
+      expect(flash[:alert]).to be_present
     end
   end
 
   describe 'POST #create' do
+    let(:staff_user) { User.create!(email: 'teacher@example.com', canvas_uid: '999', name: 'Teacher') }
+
+    before do
+      session[:user_id] = staff_user.canvas_uid
+      UserToCourse.create!(user: staff_user, course: course, role: 'teacher')
+      staff_user.lms_credentials.create!(
+        lms_name: 'canvas',
+        token: 'fake_token',
+        refresh_token: 'fake_refresh_token',
+        expire_time: 1.hour.from_now
+      )
+    end
+
     it 'redirects to courses_path after importing courses' do
       allow(Course).to receive_messages(fetch_courses: [
                                           { 'id' => '456', 'name' => 'New Canvas Course', 'course_code' => 'C101', 'enrollments' => [ { 'type' => 'teacher' } ] }
@@ -79,6 +92,19 @@ RSpec.describe CoursesController, type: :controller do
   end
 
   describe 'POST #sync_assignments' do
+    let(:staff_user) { User.create!(email: 'teacher@example.com', canvas_uid: '999', name: 'Teacher') }
+
+    before do
+      session[:user_id] = staff_user.canvas_uid
+      UserToCourse.create!(user: staff_user, course: course, role: 'ta')
+      staff_user.lms_credentials.create!(
+        lms_name: 'canvas',
+        token: 'fake_token',
+        refresh_token: 'fake_refresh_token',
+        expire_time: 1.hour.from_now
+      )
+    end
+
     it 'syncs assignments and returns OK' do
       allow(Course).to receive(:create_or_update_from_canvas)
 
@@ -90,8 +116,19 @@ RSpec.describe CoursesController, type: :controller do
   end
 
   describe 'POST #sync_enrollments' do
+    let(:staff_user) { User.create!(email: 'teacher@example.com', canvas_uid: '999', name: 'Teacher') }
+
     before do
       course_to_lms
+      session[:user_id] = staff_user.canvas_uid
+      UserToCourse.create!(user: staff_user, course: course, role: 'ta')
+      staff_user.lms_credentials.create!(
+        lms_name: 'canvas',
+        token: 'fake_token',
+        refresh_token: 'fake_refresh_token',
+        expire_time: 1.hour.from_now
+      )
+
       roles = %w[teacher ta student]
       roles.each do |role|
         stub_request(:get, "#{ENV.fetch('CANVAS_URL', nil)}/api/v1/courses/456/users")

--- a/spec/controllers/form_settings_controller_spec.rb
+++ b/spec/controllers/form_settings_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe FormSettingsController, type: :controller do
   let(:user) { User.create!(email: 'instructor@example.com', canvas_uid: '12345', name: 'Instructor') }
   let(:course) { Course.create!(course_name: 'Algorithms', canvas_id: '789', course_code: 'CS101') }
-  let(:user_to_course) { UserToCourse.create!(user: user, course: course, role: 'teacher') }
   let(:valid_params) do
     {
       course_id: course.id,
@@ -23,7 +22,13 @@ RSpec.describe FormSettingsController, type: :controller do
 
   before do
     session[:user_id] = user.canvas_uid
-    allow_any_instance_of(Course).to receive(:user_role).and_return('instructor')
+    UserToCourse.create!(user: user, course: course, role: 'teacher')
+    user.lms_credentials.create!(
+      lms_name: 'canvas',
+      token: 'fake_token',
+      refresh_token: 'fake_refresh_token',
+      expire_time: 1.hour.from_now
+    )
     course.create_form_setting!(
       documentation_disp: 'hidden',
       custom_q1_disp: 'optional',
@@ -114,14 +119,23 @@ RSpec.describe FormSettingsController, type: :controller do
     end
 
     context 'when user is a student' do
+      let(:student) { User.create!(email: 'student@example.com', canvas_uid: '99999', name: 'Student') }
+
       before do
-        allow_any_instance_of(Course).to receive(:user_role).and_return('student')
+        session[:user_id] = student.canvas_uid
+        UserToCourse.create!(user: student, course: course, role: 'student')
+        student.lms_credentials.create!(
+          lms_name: 'canvas',
+          token: 'student_token',
+          refresh_token: 'student_refresh_token',
+          expire_time: 1.hour.from_now
+        )
       end
 
       it 'denies access and redirects to courses path' do
         patch :update, params: valid_params
         expect(response).to redirect_to(courses_path)
-        expect(flash[:alert]).to eq('You do not have access to this page.')
+        expect(flash[:alert]).to be_present
       end
     end
   end

--- a/spec/controllers/user_to_courses_controller_spec.rb
+++ b/spec/controllers/user_to_courses_controller_spec.rb
@@ -75,15 +75,15 @@ RSpec.describe UserToCoursesController, type: :controller do
         )
       end
 
-      it 'returns forbidden status' do
+      it 'denies access' do
         patch :toggle_allow_extended_requests, params: {
           course_id: course.id,
           id: student_enrollment.id,
           allow_extended_requests: true
         }
 
-        expect(response).to have_http_status(:forbidden)
-        expect(response.parsed_body['redirect_to']).to be_present
+        expect(response).to redirect_to(courses_path)
+        expect(flash[:alert]).to be_present
       end
 
       it 'does not update the enrollment' do

--- a/spec/factories/user_to_course.rb
+++ b/spec/factories/user_to_course.rb
@@ -11,5 +11,13 @@ FactoryBot.define do
     trait :as_student do
       role { 'student' }
     end
+
+    trait :as_ta do
+      role { 'ta' }
+    end
+
+    trait :as_leadta do
+      role { 'leadta' }
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe Ability do
+  subject(:ability) { described_class.new(user) }
+
+  let(:course) { create(:course) }
+  let(:other_course) { create(:course) }
+
+  # Helper to create a request using the course's existing assignment
+  def create_request_for(course, user: nil)
+    assignment = course.assignments.first
+    attrs = { course: course, assignment: assignment }
+    attrs[:user] = user if user
+    create(:request, **attrs)
+  end
+
+  describe 'unauthenticated user (nil)' do
+    let(:user) { nil }
+
+    it 'cannot do anything' do
+      expect(ability).not_to be_able_to(:read, course)
+      expect(ability).not_to be_able_to(:import, Course)
+    end
+  end
+
+  describe 'site admin' do
+    let(:user) { create(:user, admin: true) }
+
+    it 'can manage everything' do
+      expect(ability).to be_able_to(:manage, :all)
+    end
+
+    it 'can manage any course' do
+      expect(ability).to be_able_to(:manage, course)
+    end
+
+    it 'can manage course settings' do
+      expect(ability).to be_able_to(:update, course.course_settings)
+    end
+
+    it 'can manage form settings' do
+      expect(ability).to be_able_to(:update, course.form_setting)
+    end
+
+    it 'can import courses' do
+      expect(ability).to be_able_to(:import, Course)
+    end
+  end
+
+  describe 'course admin (teacher)' do
+    let(:user) { create(:user) }
+
+    before do
+      create(:user_to_course, :as_teacher, user: user, course: course)
+    end
+
+    it 'can manage the course' do
+      expect(ability).to be_able_to(:manage, course)
+    end
+
+    it 'can update course settings' do
+      expect(ability).to be_able_to(:update, course.course_settings)
+    end
+
+    it 'can update form settings' do
+      expect(ability).to be_able_to(:update, course.form_setting)
+    end
+
+    it 'can manage requests in the course' do
+      request = create_request_for(course)
+      expect(ability).to be_able_to(:manage, request)
+    end
+
+    it 'can manage assignments in the course' do
+      assignment = course.assignments.first
+      expect(ability).to be_able_to(:manage, assignment)
+    end
+
+    it 'can manage enrollments (UserToCourse) in the course' do
+      enrollment = course.user_to_courses.first
+      expect(ability).to be_able_to(:toggle_allow_extended_requests, enrollment) if enrollment
+    end
+
+    it 'can destroy the course' do
+      expect(ability).to be_able_to(:destroy, course)
+    end
+
+    it 'can sync assignments' do
+      expect(ability).to be_able_to(:sync_assignments, course)
+    end
+
+    it 'can sync enrollments' do
+      expect(ability).to be_able_to(:sync_enrollments, course)
+    end
+
+    it 'can view enrollments' do
+      expect(ability).to be_able_to(:enrollments, course)
+    end
+
+    it 'can create courses' do
+      expect(ability).to be_able_to(:create, Course)
+    end
+
+    it 'can import courses' do
+      expect(ability).to be_able_to(:import, Course)
+    end
+
+    it 'cannot manage a different course' do
+      expect(ability).not_to be_able_to(:manage, other_course)
+    end
+
+    it 'cannot manage requests in a different course' do
+      other_request = create_request_for(other_course)
+      expect(ability).not_to be_able_to(:manage, other_request)
+    end
+  end
+
+  describe 'course admin (lead TA)' do
+    let(:user) { create(:user) }
+
+    before do
+      create(:user_to_course, :as_leadta, user: user, course: course)
+    end
+
+    it 'can manage the course' do
+      expect(ability).to be_able_to(:manage, course)
+    end
+
+    it 'can update course settings' do
+      expect(ability).to be_able_to(:update, course.course_settings)
+    end
+
+    it 'can update form settings' do
+      expect(ability).to be_able_to(:update, course.form_setting)
+    end
+
+    it 'can manage requests' do
+      request = create_request_for(course)
+      expect(ability).to be_able_to(:approve, request)
+      expect(ability).to be_able_to(:reject, request)
+    end
+
+    it 'can toggle extended circumstances' do
+      student_user = create(:user)
+      enrollment = create(:user_to_course, user: student_user, course: course, role: 'student')
+      expect(ability).to be_able_to(:toggle_allow_extended_requests, enrollment)
+    end
+
+    it 'can create courses' do
+      expect(ability).to be_able_to(:create, Course)
+    end
+  end
+
+  describe 'regular TA' do
+    let(:user) { create(:user) }
+
+    before do
+      create(:user_to_course, :as_ta, user: user, course: course)
+    end
+
+    it 'can read the course' do
+      expect(ability).to be_able_to(:read, course)
+    end
+
+    it 'can sync assignments' do
+      expect(ability).to be_able_to(:sync_assignments, course)
+    end
+
+    it 'can sync enrollments' do
+      expect(ability).to be_able_to(:sync_enrollments, course)
+    end
+
+    it 'can view enrollments' do
+      expect(ability).to be_able_to(:enrollments, course)
+    end
+
+    it 'can read requests' do
+      request = create_request_for(course)
+      expect(ability).to be_able_to(:read, request)
+    end
+
+    it 'can approve requests' do
+      request = create_request_for(course)
+      expect(ability).to be_able_to(:approve, request)
+    end
+
+    it 'can reject requests' do
+      request = create_request_for(course)
+      expect(ability).to be_able_to(:reject, request)
+    end
+
+    it 'can create requests for students' do
+      expect(ability).to be_able_to(:create_for_student, Request.new(course: course))
+    end
+
+    it 'can toggle assignment enabled status' do
+      assignment = course.assignments.first
+      expect(ability).to be_able_to(:toggle_enabled, assignment)
+    end
+
+    it 'can read assignments' do
+      assignment = course.assignments.first
+      expect(ability).to be_able_to(:read, assignment)
+    end
+
+    it 'can create courses' do
+      expect(ability).to be_able_to(:create, Course)
+    end
+
+    it 'can import courses' do
+      expect(ability).to be_able_to(:import, Course)
+    end
+
+    it 'cannot update course settings' do
+      expect(ability).not_to be_able_to(:update, course.course_settings)
+    end
+
+    it 'cannot update form settings' do
+      expect(ability).not_to be_able_to(:update, course.form_setting)
+    end
+
+    it 'cannot destroy the course' do
+      expect(ability).not_to be_able_to(:destroy, course)
+    end
+
+    it 'cannot update the course' do
+      expect(ability).not_to be_able_to(:update, course)
+    end
+
+    it 'cannot toggle extended circumstances' do
+      student_user = create(:user)
+      enrollment = create(:user_to_course, user: student_user, course: course, role: 'student')
+      expect(ability).not_to be_able_to(:toggle_allow_extended_requests, enrollment)
+    end
+
+    it 'cannot manage a different course' do
+      expect(ability).not_to be_able_to(:read, other_course)
+    end
+  end
+
+  describe 'student' do
+    let(:user) { create(:user) }
+    let(:other_student) { create(:user) }
+
+    before do
+      create(:user_to_course, :as_student, user: user, course: course)
+      create(:user_to_course, :as_student, user: other_student, course: course)
+    end
+
+    it 'can read the course' do
+      expect(ability).to be_able_to(:read, course)
+    end
+
+    it 'can read assignments' do
+      assignment = course.assignments.first
+      expect(ability).to be_able_to(:read, assignment)
+    end
+
+    it 'can create own requests' do
+      expect(ability).to be_able_to(:create, Request.new(course: course, user: user))
+    end
+
+    it 'can read own requests' do
+      request = create_request_for(course, user: user)
+      expect(ability).to be_able_to(:read, request)
+    end
+
+    it 'can update own requests' do
+      request = create_request_for(course, user: user)
+      expect(ability).to be_able_to(:update, request)
+    end
+
+    it 'can cancel own requests' do
+      request = create_request_for(course, user: user)
+      expect(ability).to be_able_to(:cancel, request)
+    end
+
+    it 'cannot read other students\' requests' do
+      other_request = create_request_for(course, user: other_student)
+      expect(ability).not_to be_able_to(:read, other_request)
+    end
+
+    it 'cannot update other students\' requests' do
+      other_request = create_request_for(course, user: other_student)
+      expect(ability).not_to be_able_to(:update, other_request)
+    end
+
+    it 'cannot approve requests' do
+      request = create_request_for(course, user: user)
+      expect(ability).not_to be_able_to(:approve, request)
+    end
+
+    it 'cannot reject requests' do
+      request = create_request_for(course, user: user)
+      expect(ability).not_to be_able_to(:reject, request)
+    end
+
+    it 'cannot update course settings' do
+      expect(ability).not_to be_able_to(:update, course.course_settings)
+    end
+
+    it 'cannot update form settings' do
+      expect(ability).not_to be_able_to(:update, course.form_setting)
+    end
+
+    it 'cannot toggle assignment enabled status' do
+      assignment = course.assignments.first
+      expect(ability).not_to be_able_to(:toggle_enabled, assignment)
+    end
+
+    it 'cannot destroy the course' do
+      expect(ability).not_to be_able_to(:destroy, course)
+    end
+
+    it 'cannot sync assignments' do
+      expect(ability).not_to be_able_to(:sync_assignments, course)
+    end
+
+    it 'cannot sync enrollments' do
+      expect(ability).not_to be_able_to(:sync_enrollments, course)
+    end
+
+    it 'cannot create courses' do
+      expect(ability).not_to be_able_to(:create, Course)
+    end
+
+    it 'can import courses (view import page)' do
+      expect(ability).to be_able_to(:import, Course)
+    end
+
+    it 'cannot toggle extended circumstances' do
+      enrollment = course.user_to_courses.find_by(user: user)
+      expect(ability).not_to be_able_to(:toggle_allow_extended_requests, enrollment)
+    end
+
+    it 'cannot access a different course' do
+      expect(ability).not_to be_able_to(:read, other_course)
+    end
+  end
+
+  describe 'user with no enrollments' do
+    let(:user) { create(:user) }
+
+    it 'can view the import page' do
+      expect(ability).to be_able_to(:import, Course)
+    end
+
+    it 'cannot create courses' do
+      expect(ability).not_to be_able_to(:create, Course)
+    end
+
+    it 'cannot read any course' do
+      expect(ability).not_to be_able_to(:read, course)
+    end
+  end
+
+  describe 'user with multiple roles across courses' do
+    let(:user) { create(:user) }
+
+    before do
+      create(:user_to_course, :as_teacher, user: user, course: course)
+      create(:user_to_course, :as_student, user: user, course: other_course)
+    end
+
+    it 'can manage the course where they are a teacher' do
+      expect(ability).to be_able_to(:manage, course)
+    end
+
+    it 'can only read the course where they are a student' do
+      expect(ability).to be_able_to(:read, other_course)
+      expect(ability).not_to be_able_to(:update, other_course)
+    end
+
+    it 'can update settings for teacher course but not student course' do
+      expect(ability).to be_able_to(:update, course.course_settings)
+      expect(ability).not_to be_able_to(:update, other_course.course_settings)
+    end
+  end
+
+  describe 'removed enrollment' do
+    let(:user) { create(:user) }
+
+    before do
+      create(:user_to_course, :as_teacher, user: user, course: course, removed: true)
+    end
+
+    it 'cannot access the course' do
+      expect(ability).not_to be_able_to(:read, course)
+    end
+
+    it 'cannot manage the course' do
+      expect(ability).not_to be_able_to(:manage, course)
+    end
+  end
+end


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

This PR refactors the permissions system to use the [CanCanCan](https://github.com/CanCanCommunity/cancancan) gem, replacing ad-hoc role checks scattered across controllers with a centralized `Ability` model.

## Why

Previously, authorization was handled inconsistently — some controllers checked `@role == 'instructor'`, others used `params[:role]` (an insecure pattern that allowed clients to self-report their role), and some had no checks at all. This made it difficult to reason about what each role could do and easy to miss edge cases.

## What Changed

### Permissions Model (`app/models/ability.rb`)
A new `Ability` class defines all permissions in one place:

- **Site admins**: Full access to everything
- **Course admins** (teachers + lead TAs): Full management of their specific courses, including settings, requests, assignments, and enrollments
- **Regular TAs**: Can view everything within a course, approve/deny requests, toggle assignments, and sync assignments/enrollments — but **cannot** update `CourseSettings`, `FormSetting`, or toggle extended circumstances status
- **Students**: Can only read their course/assignments and manage their own extension requests
- **Any staff member** (in any course): Can create/import new courses
- **All logged-in users**: Can view the course import page

Removed enrollments (`removed: true`) are excluded from all permission grants.

### Bug Fix
`Course#user_role` was not mapping `leadta` to the `instructor` role — it only checked for `teacher` and `ta`. This has been fixed to use `UserToCourse.staff_roles`.

### Controller Updates
- **`ApplicationController`**: Added a global `rescue_from CanCan::AccessDenied` handler (supports HTML and JSON responses). Simplified `ensure_instructor_role` to delegate to CanCanCan.
- **`CoursesController`**: Added `authorize!` calls for `show`, `new`, `edit`, `create`, `sync_assignments`, `sync_enrollments`, `enrollments`, and `delete`. Fixed `index` to include `leadta` in the staff courses listing.
- **`RequestsController`**: Added `authorize!` for all sensitive actions; removed the old `check_instructor_permission` before-action.
- **`CourseSettingsController`** / **`FormSettingsController`**: Replaced `ensure_instructor_role` with model-specific authorization helpers.
- **`AssignmentsController`**: Replaced manual role check (which used `params[:role]`) with `authorize! :toggle_enabled, @assignment`.
- **`UserToCoursesController`**: Replaced `ensure_course_admin` with `authorize! :toggle_allow_extended_requests, @enrollment`.

# Testing

- Added **72 new `Ability` spec tests** covering all roles (admin, teacher, lead TA, TA, student, unauthenticated, multi-role, and removed enrollment scenarios).
- Updated existing controller specs to use real database enrollments instead of mocked roles or `params[:role]`, making tests more accurate and secure.
- Added `:as_ta` and `:as_leadta` factory traits for `UserToCourse`.
- All existing tests pass with the refactored authorization.

# Documentation

No additional documentation required. The `Ability` model itself serves as the canonical reference for what each role can do.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/TPQrwMP9GbR6/implementations/67p6mhdr6wTb) | [App Preview](https://www.superconductor.com/tickets/TPQrwMP9GbR6/implementations/67p6mhdr6wTb/preview) | [Guided Review](https://www.superconductor.com/tickets/TPQrwMP9GbR6/implementations/67p6mhdr6wTb?tab=guided_review)

<!-- created-by-superconductor -->