### PR TITLE
Refactor RBAC permissions logic to centralize and test without external gems

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Authorization
+
   before_action :authenticated!, unless: -> { excluded_controller_action? }
 
   rescue_from LmsFacade::LmsAPIError, with: :handle_lms_api_error
@@ -18,7 +20,6 @@ class ApplicationController < ActionController::Base
     excluded_actions[controller]&.include?(action)
   end
 
-  # TODO: Refactor all auth methods
   helper_method :current_user
   def current_user
     if defined?(@current_user)
@@ -79,8 +80,8 @@ class ApplicationController < ActionController::Base
 
   def set_pending_request_count
     return unless defined?(@course) && @course.present? && defined?(@user) && @user.present?
-    # only calculating pending requests count if the role is instructor so we don't show it to students
-    return unless @course.user_role(@user) == 'instructor'
+
+    return unless current_policy.staff?
 
     @pending_requests_count = @course.requests.where(status: 'pending').count
   end
@@ -99,7 +100,7 @@ class ApplicationController < ActionController::Base
     instructor_view = "#{ctrl}/instructor_#{act}"
     student_view = "#{ctrl}/student_#{act}"
 
-    case @role
+    case current_policy.view_role
     when 'instructor'
       render instructor_view
     when 'student'
@@ -122,9 +123,6 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_instructor_role
-    return if @role == 'instructor'
-
-    flash[:alert] = 'You do not have access to this page.'
-    redirect_to courses_path
+    authorize! :staff?
   end
 end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,20 +1,17 @@
 class AssignmentsController < ApplicationController
   def toggle_enabled
     @assignment = Assignment.find(params[:id])
-    course = @assignment.course_to_lms.course
-    @role = params[:role] || course&.user_role(@user)
+    @course = @assignment.course_to_lms.course
+    @role = @course&.user_role(current_user)
 
-    unless @role == 'instructor'
-      Rails.logger.error "Role #{@role} does not have permission to toggle assignment enabled status"
-      flash.now[:alert] = 'You do not have permission to perform this action.'
-      return render json: { redirect_to: course_path(course) }, status: :forbidden
-    end
+    authorize! :can_toggle_assignment?, format: :json
+    return if performed?
 
     if @assignment.update(enabled: params[:enabled])
       render json: { success: true }, status: :ok
     else
       flash[:alert] = "Failed to update assignment: #{@assignment.errors.full_messages.to_sentence}"
-      render json: { redirect_to: course_path(course) }, status: :unprocessable_content
+      render json: { redirect_to: course_path(@course) }, status: :unprocessable_content
     end
   end
 end

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -1,0 +1,47 @@
+module Authorization
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_policy
+  end
+
+  private
+
+  def current_policy
+    @current_policy ||= CoursePolicy.new(current_user, @course)
+  end
+
+  # Authorize an action using CoursePolicy. Redirects or renders 403 on failure.
+  #
+  # When used as a before_action, Rails automatically halts the filter chain
+  # after a redirect/render. When used inline in an action method, the caller
+  # must add `return if performed?` after the call to prevent double renders.
+  #
+  # Usage:
+  #   before_action -> { authorize! :can_manage_settings? }
+  #   # or define a named method:
+  #   def authorize_manage_settings = authorize!(:can_manage_settings?)
+  #
+  # Inline usage:
+  #   authorize! :can_edit_course?
+  #   return if performed?
+  def authorize!(permission, format: nil)
+    return if current_policy.public_send(permission)
+
+    deny_access!(format: format)
+  end
+
+  def deny_access!(format: nil, message: 'You do not have permission to perform this action.')
+    format ||= request.format.symbol
+
+    if format == :json
+      render json: { error: message, redirect_to: fallback_redirect_path }, status: :forbidden
+    else
+      redirect_to(fallback_redirect_path, alert: message)
+    end
+  end
+
+  def fallback_redirect_path
+    @course ? course_path(@course) : courses_path
+  end
+end

--- a/app/controllers/course_settings_controller.rb
+++ b/app/controllers/course_settings_controller.rb
@@ -2,7 +2,7 @@ class CourseSettingsController < ApplicationController
   before_action :authenticated!
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_instructor_role
+  before_action :authorize_manage_settings
   before_action :set_pending_request_count
 
   # Default template settings
@@ -74,6 +74,10 @@ class CourseSettingsController < ApplicationController
       :enable_slack_webhook_url,
       :slack_webhook_url
     )
+  end
+
+  def authorize_manage_settings
+    authorize! :can_manage_settings?
   end
 
   def set_pending_request_count

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,7 +5,7 @@ class CoursesController < ApplicationController
   before_action :determine_user_role
 
   def index
-    @teacher_courses = UserToCourse.includes(:course).where(user: @user, role: %w[teacher ta])
+    @teacher_courses = UserToCourse.includes(:course).where(user: @user, role: UserToCourse.staff_roles)
 
     # Only show courses to students if extensions are enabled at the course level
     student_courses = UserToCourse.includes(course: :course_settings).where(user: @user, role: 'student')
@@ -22,7 +22,7 @@ class CoursesController < ApplicationController
     @side_nav = 'show'
     @course.regenerate_readonly_api_token_if_blank
 
-    if @role == 'student'
+    if current_policy.student? && !current_policy.staff?
       course_settings = @course.course_settings
       return redirect_to courses_path, alert: 'Extensions are not enabled for this course.' unless course_settings&.enable_extensions
 
@@ -43,8 +43,6 @@ class CoursesController < ApplicationController
     @selected_semester = params[:semester]
 
     teacher_enrollment_types = %w[teacher ta]
-    # TODO: Add spec for when a course is created, but the user is not enrolled in it.
-    # TODO: Why do some courses have empty enrollments?
     existing_canvas_ids = @user.courses.pluck(:canvas_id)
     @courses_teacher = filter_courses(@courses, teacher_enrollment_types, existing_canvas_ids)
     @courses_student = filter_courses(@courses, [ 'student' ], existing_canvas_ids)
@@ -57,7 +55,7 @@ class CoursesController < ApplicationController
 
   def edit
     @side_nav = 'edit'
-    redirect_to course_path(@course.id), alert: 'You do not have access to this page.' unless @role == 'instructor'
+    authorize! :can_edit_course?
   end
 
   def create
@@ -71,6 +69,9 @@ class CoursesController < ApplicationController
   def sync_assignments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
 
+    authorize! :can_sync_assignments?, format: :json
+    return if performed?
+
     @course.sync_assignments(@user)
     render json: { message: 'Assignments synced successfully.' }, status: :ok
   end
@@ -78,20 +79,25 @@ class CoursesController < ApplicationController
   def sync_enrollments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
 
+    authorize! :can_sync_enrollments?, format: :json
+    return if performed?
+
     @course.sync_all_enrollments_from_canvas(@user.id)
     render json: { message: 'Users synced successfully.' }, status: :ok
   end
 
   def enrollments
     @side_nav = 'enrollments'
-    return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
+    authorize! :can_view_enrollments?
+    return if performed?
 
     @enrollments = @course.user_to_courses.includes(:user)
-    @is_course_admin = @course.user_to_courses.find_by(user: @user)&.course_admin?
+    @is_course_admin = current_policy.course_admin?
   end
 
   def delete
-    return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
+    authorize! :can_delete_course?
+    return if performed?
     return redirect_to courses_path, alert: 'Extensions are enabled for this course.' if @course.course_settings&.enable_extensions
 
     assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: @course.id).select(:id))

--- a/app/controllers/form_settings_controller.rb
+++ b/app/controllers/form_settings_controller.rb
@@ -2,7 +2,7 @@ class FormSettingsController < ApplicationController
   before_action :authenticated!
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_instructor_role
+  before_action :authorize_manage_form_settings
   before_action :set_pending_request_count
 
   def edit
@@ -42,6 +42,10 @@ class FormSettingsController < ApplicationController
       :custom_q1, :custom_q1_desc, :custom_q1_disp,
       :custom_q2, :custom_q2_desc, :custom_q2_disp
     )
+  end
+
+  def authorize_manage_form_settings
+    authorize! :can_manage_form_settings?
   end
 
   def set_pending_request_count

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -11,11 +11,11 @@ class RequestsController < ApplicationController
   before_action :check_extensions_enabled_for_students, except: [ :export ]
   before_action :ensure_request_is_pending, only: %i[update approve reject]
   before_action :set_request, only: %i[show edit cancel]
-  before_action :check_instructor_permission, only: %i[approve reject mass_approve mass_reject]
+  before_action :authorize_approve_deny, only: %i[approve reject mass_approve mass_reject]
 
   def index
     @side_nav = 'requests'
-    if @role == 'student'
+    if !current_policy.staff?
       @requests = @course.requests.for_user(@user)
     elsif params[:show_all] == 'true'
       @requests = @course.requests.includes(:assignment)
@@ -41,10 +41,10 @@ class RequestsController < ApplicationController
     course_to_lmss = @course.all_linked_lmss.pluck(:id)
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
 
-    if @role == 'instructor'
+    if current_policy.staff?
       prepare_instructor_new_request(course_to_lmss)
       render :new_for_student and return
-    elsif @role == 'student'
+    elsif current_policy.student?
       redirected = prepare_student_new_request(course_to_lmss)
       return if redirected
 
@@ -56,7 +56,7 @@ class RequestsController < ApplicationController
 
   def new_for_student
     @side_nav = 'form'
-    return redirect_to course_requests_path(@course), alert: 'You do not have permission to access this page.' unless @role == 'instructor'
+    return redirect_to course_requests_path(@course), alert: 'You do not have permission to access this page.' unless current_policy.staff?
 
     course_to_lmss = @course.all_linked_lmss.pluck(:id)
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
@@ -91,7 +91,7 @@ class RequestsController < ApplicationController
   end
 
   def create_for_student
-    return redirect_to course_requests_path(@course), alert: 'You do not have permission to perform this action.' unless @role == 'instructor'
+    return redirect_to course_requests_path(@course), alert: 'You do not have permission to perform this action.' unless current_policy.staff?
 
     student = User.find_by(id: params[:request][:user_id])
     return redirect_to new_course_request_path(@course), alert: 'Student not found.' unless student
@@ -126,6 +126,9 @@ class RequestsController < ApplicationController
   end
 
   def cancel
+    authorize! :can_cancel_request?
+    return if performed?
+
     if @request.reject(@user)
       redirect_to course_requests_path(@course), notice: 'Request canceled successfully.'
     else
@@ -196,9 +199,8 @@ class RequestsController < ApplicationController
     redirect_to course_path(@course), alert: 'Request not found.' unless @request
   end
 
-  def check_instructor_permission
-    result = RequestService.check_instructor_permission(@role, course_path(@course))
-    redirect_to result[:redirect_to], alert: result[:alert] if result != true
+  def authorize_approve_deny
+    authorize! :can_approve_or_deny_requests?
   end
 
   def handle_request_error
@@ -248,7 +250,7 @@ class RequestsController < ApplicationController
   end
 
   def check_extensions_enabled_for_students
-    result = RequestService.check_extensions_enabled_for_students(@role, @course, courses_path)
+    result = RequestService.check_extensions_enabled_for_students(current_policy, @course, courses_path)
     redirect_to result[:redirect_to], alert: result[:alert] if result != true
   end
 

--- a/app/controllers/user_to_courses_controller.rb
+++ b/app/controllers/user_to_courses_controller.rb
@@ -1,9 +1,11 @@
 class UserToCoursesController < ApplicationController
   before_action :authenticate_user
   before_action :set_course
-  before_action :ensure_course_admin
 
   def toggle_allow_extended_requests
+    authorize! :can_manage_extended_circumstances?, format: :json
+    return if performed?
+
     @enrollment = @course.user_to_courses.find(params[:id])
 
     if @enrollment.update(allow_extended_requests: params[:allow_extended_requests])
@@ -12,14 +14,5 @@ class UserToCoursesController < ApplicationController
       flash[:alert] = "Failed to update enrollment: #{@enrollment.errors.full_messages.to_sentence}"
       render json: { redirect_to: course_path(@course) }, status: :unprocessable_content
     end
-  end
-
-  private
-
-  def ensure_course_admin
-    enrollment = @course.user_to_courses.find_by(user: @user)
-    return if enrollment&.course_admin?
-
-    render json: { error: 'You must be an instructor or Lead TA.', redirect_to: course_path(@course) }, status: :forbidden
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -62,11 +62,9 @@ class Course < ApplicationRecord
     assignments.where(enabled: true)
   end
 
-  # TODO: Replace this with staff_role?(user) or student_role?(user)
-  # Or is user.staff_role?(course) or user.student_role?(course) better?
   def user_role(user)
     roles = UserToCourse.where(user_id: user.id, course_id: id).pluck(:role)
-    return 'instructor' if roles.include?('teacher') || roles.include?('ta')
+    return 'instructor' if (roles & UserToCourse.staff_roles).any?
     return 'student' if roles.include?('student')
 
     nil

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -1,0 +1,149 @@
+# Centralized RBAC authorization for course-scoped actions.
+#
+# Roles (highest to lowest privilege):
+#   - site_admin: User.admin? flag, can do everything
+#   - course_admin: teacher or leadta enrollment, can manage everything in a course
+#   - ta: regular TA enrollment, can view everything, approve/deny requests, sync
+#   - student: can only manage their own extensions
+#
+# Usage:
+#   policy = CoursePolicy.new(user, course)
+#   policy.can_manage_settings?  # => true/false
+class CoursePolicy
+  attr_reader :user, :course, :enrollments
+
+  def initialize(user, course = nil)
+    @user = user
+    @course = course
+    @enrollments = if course && user
+                     course.user_to_courses.where(user: user)
+                   else
+                     UserToCourse.none
+                   end
+  end
+
+  # --- Role checks ---
+
+  def site_admin?
+    user&.admin?
+  end
+
+  def course_admin?
+    site_admin? || enrollments.any?(&:course_admin?)
+  end
+
+  def staff?
+    site_admin? || enrollments.any?(&:staff?)
+  end
+
+  def student?
+    enrollments.any?(&:student?)
+  end
+
+  def enrolled?
+    enrollments.exists?
+  end
+
+  # Returns the view-level role used for rendering (instructor/student views).
+  # This preserves the existing dual-view rendering pattern.
+  def view_role
+    return 'instructor' if staff?
+    return 'student' if student?
+
+    nil
+  end
+
+  # --- Course-level permissions ---
+
+  # Everyone can view the import course page (courses#new)
+  def can_view_import_page?
+    user.present?
+  end
+
+  # Any authenticated user can create/import courses.
+  # Canvas API enrollment filtering determines which courses appear.
+  def can_create_course?
+    user.present?
+  end
+
+  # Enrolled users can view a course (students only if extensions enabled)
+  def can_view_course?
+    site_admin? || enrolled?
+  end
+
+  # Only course admins (teacher/leadta) can edit course settings
+  def can_edit_course?
+    course_admin?
+  end
+
+  # Only course admins can delete a course
+  def can_delete_course?
+    course_admin?
+  end
+
+  # Staff can view enrollments, but only course admins can modify them
+  def can_view_enrollments?
+    staff?
+  end
+
+  # Staff can sync assignments from Canvas
+  def can_sync_assignments?
+    staff?
+  end
+
+  # Staff can sync enrollments from Canvas
+  def can_sync_enrollments?
+    staff?
+  end
+
+  # --- Request permissions ---
+
+  # Enrolled users can view requests (scoped by role in controller)
+  def can_view_requests?
+    site_admin? || enrolled?
+  end
+
+  # Students can create requests for themselves; staff can create for students
+  def can_create_request?
+    site_admin? || enrolled?
+  end
+
+  # Staff can create requests on behalf of students
+  def can_create_request_for_student?
+    staff?
+  end
+
+  # Staff can approve or deny requests (including regular TAs)
+  def can_approve_or_deny_requests?
+    staff?
+  end
+
+  # Only staff can cancel (delete) requests. Students cannot cancel requests.
+  def can_cancel_request?
+    staff?
+  end
+
+  # --- Settings permissions (course admins only, NOT regular TAs) ---
+
+  # Only course admins can update course settings
+  def can_manage_settings?
+    course_admin?
+  end
+
+  # Only course admins can update form settings
+  def can_manage_form_settings?
+    course_admin?
+  end
+
+  # Only course admins can toggle extended circumstances status
+  def can_manage_extended_circumstances?
+    course_admin?
+  end
+
+  # --- Assignment permissions ---
+
+  # Only course admins can toggle assignment enabled status (a configuration action)
+  def can_toggle_assignment?
+    course_admin?
+  end
+end

--- a/app/services/request_service.rb
+++ b/app/services/request_service.rb
@@ -6,16 +6,9 @@ class RequestService
     { redirect_to: redirect_path, alert: 'Course not found.' }
   end
 
-  # Check instructor permission
-  def self.check_instructor_permission(role, course_path)
-    return true if role == 'instructor'
-
-    { redirect_to: course_path, alert: 'You do not have permission to perform this action.' }
-  end
-
-  # Ensure extensions are enabled for students
-  def self.check_extensions_enabled_for_students(role, course, redirect_path)
-    return true unless role == 'student'
+  # Ensure extensions are enabled for students (non-staff users)
+  def self.check_extensions_enabled_for_students(policy, course, redirect_path)
+    return true if policy.staff?
 
     course_settings = course.course_settings
     return true unless course_settings && !course_settings.enable_extensions

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -27,7 +27,7 @@
 			text: "Requests  <span class=\"badge rounded-pill float-end text-bg-danger ms-2\">#{@pending_requests_count}</span>",
 			active: @side_nav == 'requests' %>
 
-		<% if @role == 'instructor' %>
+		<% if current_policy.staff? %>
 			<%= render 'layouts/components/sidebar_menu_item',
 				path: enrollments_course_path(@course.id),
 				icon: 'fas fa-users',
@@ -53,7 +53,7 @@
 				active: @side_nav == 'form' %>
 		<% end %>
 
-		<% if @role == 'student' %>
+		<% if current_policy.student? && !current_policy.staff? %>
 			<%= render 'layouts/components/sidebar_menu_item',
 				path: new_course_request_path(@course.id),
 				icon: 'fas fa-file-pen',

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe ApplicationController, type: :controller do
       let(:action_name_override)     { 'show' }
 
       before do
-        controller.instance_variable_set(:@role, 'student')
+        policy = instance_double(CoursePolicy, view_role: 'student')
+        allow(controller).to receive(:current_policy).and_return(policy)
       end
 
       it 'renders courses/student_show' do
@@ -122,7 +123,8 @@ RSpec.describe ApplicationController, type: :controller do
       let(:action_name_override)     { 'index' }
 
       before do
-        controller.instance_variable_set(:@role, 'instructor')
+        policy = instance_double(CoursePolicy, view_role: 'instructor')
+        allow(controller).to receive(:current_policy).and_return(policy)
       end
 
       it 'renders requests/instructor_index' do
@@ -136,7 +138,8 @@ RSpec.describe ApplicationController, type: :controller do
       let(:action_name_override)     { 'show' }
 
       before do
-        controller.instance_variable_set(:@role, 'student')
+        policy = instance_double(CoursePolicy, view_role: 'student')
+        allow(controller).to receive(:current_policy).and_return(policy)
       end
 
       it 'renders the overridden student view under requests' do
@@ -145,12 +148,13 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
 
-    context 'when @role is nil or unrecognized' do
+    context 'when view_role is nil (unenrolled user)' do
       let(:controller_name_override) { 'courses' }
       let(:action_name_override)     { 'show' }
 
       before do
-        controller.instance_variable_set(:@role, nil)
+        policy = instance_double(CoursePolicy, view_role: nil)
+        allow(controller).to receive(:current_policy).and_return(policy)
       end
 
       it 'redirects to courses_path with an alert' do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -2,32 +2,38 @@
 require 'rails_helper'
 
 RSpec.describe AssignmentsController, type: :controller do
+  let!(:user) { User.create!(name: 'Test User', email: 'test@example.com', canvas_uid: '123') }
+  let!(:course) { Course.create!(course_name: 'Test Course', canvas_id: '123') }
+  let!(:course_to_lms) { CourseToLms.create!(course: course, lms_id: 1, external_course_id: '123') }
+  let!(:course_settings) { CourseSettings.create!(course: course, enable_extensions: true) }
+  let!(:assignment) do
+    Assignment.create!(
+      name: 'Test Assignment',
+      course_to_lms: course_to_lms,
+      due_date: 3.days.from_now,
+      external_assignment_id: 'abc123',
+      enabled: false
+    )
+  end
+
   before do
-    session[:user_id] = '123'
+    session[:user_id] = user.canvas_uid
+    user.lms_credentials.create!(
+      lms_name: 'canvas',
+      token: 'fake_token',
+      refresh_token: 'fake_refresh_token',
+      expire_time: 1.hour.from_now
+    )
   end
 
   describe 'POST #toggle_enabled' do
-    let!(:user) { User.create!(name: 'Test User', email: 'test@example.com') }
-    let!(:course) { Course.create!(course_name: 'Test Course', canvas_id: '123') }
-    let!(:course_to_lms) { CourseToLms.create!(course: course, lms_id: 1, external_course_id: '123') }
-    let!(:course_settings) { CourseSettings.create!(course: course, enable_extensions: true) }
-    let!(:assignment) do
-      Assignment.create!(
-        name: 'Test Assignment',
-        course_to_lms: course_to_lms,
-        due_date: 3.days.from_now,
-        external_assignment_id: 'abc123',
-        enabled: false
-      )
-    end
-
-    context 'when the user is an instructor' do
+    context 'when the user is a course admin (teacher)' do
       before do
-        allow(course).to receive(:user_role).with(user).and_return('instructor')
+        UserToCourse.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'updates the enabled status to true' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:ok)
         expect(assignment.reload.enabled).to be true
@@ -36,20 +42,33 @@ RSpec.describe AssignmentsController, type: :controller do
       it 'updates the enabled status to false' do
         assignment.update!(enabled: true)
 
-        post :toggle_enabled, params: { id: assignment.id, enabled: false, role: 'instructor', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: false }
 
         expect(response).to have_http_status(:ok)
         expect(assignment.reload.enabled).to be false
       end
     end
 
-    context 'when the user is not an instructor' do
+    context 'when the user is a regular TA' do
       before do
-        allow(course).to receive(:user_role).with(user).and_return('student')
+        UserToCourse.create!(user: user, course: course, role: 'ta')
       end
 
       it 'returns a forbidden status' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'student', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(assignment.reload.enabled).to be false
+      end
+    end
+
+    context 'when the user is a student' do
+      before do
+        UserToCourse.create!(user: user, course: course, role: 'student')
+      end
+
+      it 'returns a forbidden status' do
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:forbidden)
         expect(assignment.reload.enabled).to be false
@@ -59,11 +78,11 @@ RSpec.describe AssignmentsController, type: :controller do
     context 'when course-level extensions are disabled' do
       before do
         course_settings.update!(enable_extensions: false)
-        allow(course).to receive(:user_role).with(user).and_return('instructor')
+        UserToCourse.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'still allows enabling the assignment and returns ok status' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor', user_id: user.id }
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:ok)
         expect(assignment.reload.enabled).to be true
@@ -73,26 +92,14 @@ RSpec.describe AssignmentsController, type: :controller do
     context 'when there is no due_date on an Assignment' do
       before do
         assignment.update!(due_date: nil)
+        UserToCourse.create!(user: user, course: course, role: 'teacher')
       end
 
-      it 'returns a bad request status' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor', user_id: user.id }
+      it 'returns an unprocessable content status' do
+        post :toggle_enabled, params: { id: assignment.id, enabled: true }
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(flash[:alert]).to include('Due date must be present if assignment is enabled')
-      end
-    end
-
-    context 'when user_id is not provided' do
-      before do
-        allow(course).to receive(:user_role).and_return('instructor')
-      end
-
-      it 'uses the session user and updates the assignment' do
-        post :toggle_enabled, params: { id: assignment.id, enabled: true, role: 'instructor' }
-
-        expect(response).to have_http_status(:ok)
-        expect(assignment.reload.enabled).to be true
       end
     end
   end

--- a/spec/controllers/course_settings_controller_spec.rb
+++ b/spec/controllers/course_settings_controller_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe CourseSettingsController, type: :controller do
   describe 'instructor access' do
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
-      allow_any_instance_of(Course).to receive(:user_role).with(instructor).and_return('instructor')
+      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
     end
 
     describe 'POST #update' do
@@ -113,15 +112,13 @@ RSpec.describe CourseSettingsController, type: :controller do
 
         expect(response).to redirect_to(course_settings_path(course.id, tab: 'email'))
         expect(flash[:notice]).to eq('Email templates reset to defaults.')
-        # We won't test the exact content since that requires knowledge of the constants
       end
     end
   end
 
   describe 'pending requests count' do
     let(:assignment) do
-      # Create necessary related objects for Request
-      lms = Lms.first
+      lms = Lms.find_or_create_by!(id: 1, lms_name: 'Canvas', use_auth_token: true)
       course_to_lms = CourseToLms.create!(course: course, lms: lms, external_course_id: '123')
       Assignment.create!(
         name: 'Test Assignment',
@@ -134,8 +131,7 @@ RSpec.describe CourseSettingsController, type: :controller do
 
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
-      allow_any_instance_of(Course).to receive(:user_role).with(instructor).and_return('instructor')
+      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
 
       # Create settings to enable extensions
       CourseSettings.create!(
@@ -186,6 +182,43 @@ RSpec.describe CourseSettingsController, type: :controller do
     end
   end
 
+  describe 'regular TA access' do
+    before do
+      session[:user_id] = student.canvas_uid
+      student.lms_credentials.create!(
+        lms_name: 'canvas',
+        token: 'student_token',
+        refresh_token: 'student_refresh_token',
+        expire_time: 1.hour.from_now
+      )
+      UserToCourse.create!(user: student, course: course, role: 'ta')
+
+      CourseSettings.create!(
+        course: course,
+        enable_extensions: false,
+        auto_approve_days: 1
+      )
+    end
+
+    it 'denies TA access to update course settings' do
+      post :update, params: {
+        course_id: course.id,
+        course_settings: {
+          enable_extensions: 'true',
+          auto_approve_days: '99'
+        },
+        tab: 'general'
+      }
+
+      expect(response).to redirect_to(course_path(course))
+      expect(flash[:alert]).to eq('You do not have permission to perform this action.')
+
+      # Verify settings were not changed
+      expect(course.reload.course_settings.enable_extensions).to be false
+      expect(course.reload.course_settings.auto_approve_days).to eq(1)
+    end
+  end
+
   describe 'student access' do
     before do
       session[:user_id] = student.canvas_uid
@@ -196,9 +229,7 @@ RSpec.describe CourseSettingsController, type: :controller do
         expire_time: 1.hour.from_now
       )
       UserToCourse.create!(user: student, course: course, role: 'student')
-      allow_any_instance_of(Course).to receive(:user_role).with(student).and_return('student')
 
-      # Create some course settings to attempt to modify
       CourseSettings.create!(
         course: course,
         enable_extensions: false,
@@ -216,8 +247,8 @@ RSpec.describe CourseSettingsController, type: :controller do
         tab: 'general'
       }
 
-      expect(response).to redirect_to(courses_path)
-      expect(flash[:alert]).to eq('You do not have access to this page.')
+      expect(response).to redirect_to(course_path(course))
+      expect(flash[:alert]).to eq('You do not have permission to perform this action.')
 
       # Verify settings were not changed
       expect(course.reload.course_settings.enable_extensions).to be false
@@ -231,8 +262,8 @@ RSpec.describe CourseSettingsController, type: :controller do
         tab: 'email'
       }
 
-      expect(response).to redirect_to(courses_path)
-      expect(flash[:alert]).to eq('You do not have access to this page.')
+      expect(response).to redirect_to(course_path(course))
+      expect(flash[:alert]).to eq('You do not have permission to perform this action.')
     end
   end
 
@@ -252,7 +283,7 @@ RSpec.describe CourseSettingsController, type: :controller do
 
     it 'redirects to courses path when course is not found' do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
+      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
 
       post :update, params: {
         course_id: 999,

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe CoursesController, type: :controller do
       end
 
       it 'renders the shared role-based view with student template' do
-        # TODO: Refactor initial data setup to use factories
         course_settings
         get :show, params: { id: course.id }
         expect(response).to render_template('courses/student_show')
@@ -58,10 +57,16 @@ RSpec.describe CoursesController, type: :controller do
   end
 
   describe 'GET #edit' do
-    it 'redirects non-instructor users' do
+    it 'redirects non-course-admin users' do
       get :edit, params: { id: course.id }
       expect(response).to redirect_to(course_path(course))
-      expect(flash[:alert]).to eq('You do not have access to this page.')
+      expect(flash[:alert]).to eq('You do not have permission to perform this action.')
+    end
+
+    it 'allows teachers to edit' do
+      UserToCourse.create!(user: user, course: course, role: 'teacher')
+      get :edit, params: { id: course.id }
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -79,6 +84,10 @@ RSpec.describe CoursesController, type: :controller do
   end
 
   describe 'POST #sync_assignments' do
+    before do
+      UserToCourse.create!(user: user, course: course, role: 'teacher')
+    end
+
     it 'syncs assignments and returns OK' do
       allow(Course).to receive(:create_or_update_from_canvas)
 
@@ -87,11 +96,23 @@ RSpec.describe CoursesController, type: :controller do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({ 'message' => 'Assignments synced successfully.' })
     end
+
+    it 'returns forbidden for students' do
+      student = User.create!(email: 'other@example.com', canvas_uid: '999', name: 'Other Student')
+      student.lms_credentials.create!(lms_name: 'canvas', token: 'fake', refresh_token: 'fake', expire_time: 1.hour.from_now)
+      UserToCourse.create!(user: student, course: course, role: 'student')
+      session[:user_id] = student.canvas_uid
+
+      post :sync_assignments, params: { id: course.id }, format: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 
   describe 'POST #sync_enrollments' do
     before do
       course_to_lms
+      UserToCourse.create!(user: user, course: course, role: 'teacher')
       roles = %w[teacher ta student]
       roles.each do |role|
         stub_request(:get, "#{ENV.fetch('CANVAS_URL', nil)}/api/v1/courses/456/users")
@@ -150,9 +171,7 @@ RSpec.describe CoursesController, type: :controller do
     end
 
     before do
-      # Create a fake LMS credential with a token
       user.lms_credentials.create!(lms_name: 'canvas', token: 'fake_token', expire_time: 1.hour.from_now)
-
       allow(Course).to receive(:fetch_courses).and_return(canvas_courses)
     end
 
@@ -161,16 +180,12 @@ RSpec.describe CoursesController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:new)
-
-      # You can check that @courses_teacher and @courses_student are set
       expect(assigns(:courses_teacher)).not_to be_empty
       expect(assigns(:courses_student)).not_to be_empty
 
-      # Teacher course should be categorized correctly
       teacher_course = assigns(:courses_teacher).first
       expect(teacher_course['enrollments'].first['type']).to eq('teacher')
 
-      # Student course should be categorized correctly
       student_course = assigns(:courses_student).first
       expect(student_course['enrollments'].first['type']).to eq('student')
     end
@@ -224,7 +239,6 @@ RSpec.describe CoursesController, type: :controller do
 
   describe 'GET #enrollments' do
     before do
-      # Create LMS credentials so user has a token
       user.lms_credentials.create!(lms_name: 'canvas', token: 'fake_token', expire_time: 1.hour.from_now)
 
       # Add user as a teacher so they are allowed to view enrollments
@@ -233,7 +247,7 @@ RSpec.describe CoursesController, type: :controller do
       CourseToLms.create!(course: course, lms_id: 1)
     end
 
-    context 'when user is an instructor' do
+    context 'when user is staff' do
       it 'renders the enrollments view successfully' do
         get :enrollments, params: { id: course.id }
 
@@ -241,9 +255,22 @@ RSpec.describe CoursesController, type: :controller do
         expect(response).to render_template(:enrollments)
         expect(assigns(:enrollments)).not_to be_nil
 
-        # Check that the enrollments include the user
         enrollment_user_ids = assigns(:enrollments).map(&:user_id)
         expect(enrollment_user_ids).to include(user.id)
+      end
+    end
+
+    context 'when user is a student' do
+      it 'denies access' do
+        student = User.create!(email: 'other@example.com', canvas_uid: '999', name: 'Other Student')
+        student.lms_credentials.create!(lms_name: 'canvas', token: 'fake', refresh_token: 'fake', expire_time: 1.hour.from_now)
+        UserToCourse.create!(user: student, course: course, role: 'student')
+        session[:user_id] = student.canvas_uid
+
+        get :enrollments, params: { id: course.id }
+
+        expect(response).to redirect_to(course_path(course))
+        expect(flash[:alert]).to eq('You do not have permission to perform this action.')
       end
     end
   end

--- a/spec/controllers/form_settings_controller_spec.rb
+++ b/spec/controllers/form_settings_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe FormSettingsController, type: :controller do
   let(:user) { User.create!(email: 'instructor@example.com', canvas_uid: '12345', name: 'Instructor') }
   let(:course) { Course.create!(course_name: 'Algorithms', canvas_id: '789', course_code: 'CS101') }
-  let(:user_to_course) { UserToCourse.create!(user: user, course: course, role: 'teacher') }
   let(:valid_params) do
     {
       course_id: course.id,
@@ -23,7 +22,13 @@ RSpec.describe FormSettingsController, type: :controller do
 
   before do
     session[:user_id] = user.canvas_uid
-    allow_any_instance_of(Course).to receive(:user_role).and_return('instructor')
+    user.lms_credentials.create!(
+      lms_name: 'canvas',
+      token: 'fake_token',
+      refresh_token: 'fake_refresh_token',
+      expire_time: 1.hour.from_now
+    )
+    UserToCourse.create!(user: user, course: course, role: 'teacher')
     course.create_form_setting!(
       documentation_disp: 'hidden',
       custom_q1_disp: 'optional',
@@ -114,14 +119,23 @@ RSpec.describe FormSettingsController, type: :controller do
     end
 
     context 'when user is a student' do
+      let(:student_user) { User.create!(email: 'student@example.com', canvas_uid: '67890', name: 'Student') }
+
       before do
-        allow_any_instance_of(Course).to receive(:user_role).and_return('student')
+        session[:user_id] = student_user.canvas_uid
+        student_user.lms_credentials.create!(
+          lms_name: 'canvas',
+          token: 'student_token',
+          refresh_token: 'student_refresh',
+          expire_time: 1.hour.from_now
+        )
+        UserToCourse.create!(user: student_user, course: course, role: 'student')
       end
 
-      it 'denies access and redirects to courses path' do
+      it 'denies access and redirects' do
         patch :update, params: valid_params
-        expect(response).to redirect_to(courses_path)
-        expect(flash[:alert]).to eq('You do not have access to this page.')
+        expect(response).to redirect_to(course_path(course))
+        expect(flash[:alert]).to eq('You do not have permission to perform this action.')
       end
     end
   end

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -278,34 +278,52 @@ RSpec.describe RequestsController, type: :controller do
   end
 
   describe 'POST #cancel' do
-    before do
-      session[:user_id] = user.canvas_uid
-      UserToCourse.create!(user: user, course: course, role: 'student')
+    context 'when user is a student' do
+      before do
+        session[:user_id] = user.canvas_uid
+        UserToCourse.create!(user: user, course: course, role: 'student')
+      end
+
+      it 'denies access to cancel a request' do
+        post :cancel, params: { course_id: course.id, id: request.id }
+
+        expect(response).to redirect_to(course_path(course))
+        expect(flash[:alert]).to eq('You do not have permission to perform this action.')
+        expect(request.reload.status).to eq('pending')
+      end
     end
 
-    it 'cancels the request and updates its status to denied' do
-      post :cancel, params: { course_id: course.id, id: request.id }
+    context 'when user is staff' do
+      before do
+        session[:user_id] = instructor.canvas_uid
+        UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+        FormSetting.create!(course: course, documentation_disp: 'hidden', custom_q1_disp: 'hidden', custom_q2_disp: 'hidden')
+      end
 
-      expect(response).to redirect_to(course_requests_path(course))
-      expect(flash[:notice]).to match(/Request canceled successfully./i)
-      expect(request.reload.status).to eq('denied')
-    end
+      it 'cancels the request and updates its status to denied' do
+        post :cancel, params: { course_id: course.id, id: request.id }
 
-    it 'redirects if the request is not found' do
-      post :cancel, params: { course_id: course.id, id: '9999' }
+        expect(response).to redirect_to(course_requests_path(course))
+        expect(flash[:notice]).to match(/Request canceled successfully./i)
+        expect(request.reload.status).to eq('denied')
+      end
 
-      expect(response).to redirect_to(course_path(course))
-      expect(flash[:alert]).to eq('Request not found.')
-    end
+      it 'redirects if the request is not found' do
+        post :cancel, params: { course_id: course.id, id: '9999' }
 
-    it 'does not cancel a request if it fails to update' do
-      allow_any_instance_of(Request).to receive(:reject).and_return(false)
+        expect(response).to redirect_to(course_path(course))
+        expect(flash[:alert]).to eq('Request not found.')
+      end
 
-      post :cancel, params: { course_id: course.id, id: request.id }
+      it 'does not cancel a request if it fails to update' do
+        allow_any_instance_of(Request).to receive(:reject).and_return(false)
 
-      expect(response).to redirect_to(course_requests_path(course))
-      expect(flash[:alert]).to match('Failed to cancel the request.')
-      expect(request.reload.status).not_to eq('denied')
+        post :cancel, params: { course_id: course.id, id: request.id }
+
+        expect(response).to redirect_to(course_requests_path(course))
+        expect(flash[:alert]).to match('Failed to cancel the request.')
+        expect(request.reload.status).not_to eq('denied')
+      end
     end
   end
 

--- a/spec/controllers/user_to_courses_controller_spec.rb
+++ b/spec/controllers/user_to_courses_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UserToCoursesController, type: :controller do
   let(:student_enrollment) { UserToCourse.create!(user: student_user, course: course, role: 'student') }
 
   describe 'PATCH #toggle_allow_extended_requests' do
-    context 'when user is an instructor' do
+    context 'when user is a course admin (teacher)' do
       before do
         UserToCourse.create!(user: instructor, course: course, role: 'teacher')
         student_enrollment
@@ -63,6 +63,69 @@ RSpec.describe UserToCoursesController, type: :controller do
       end
     end
 
+    context 'when user is a lead TA' do
+      let(:leadta) { User.create!(email: 'leadta@example.com', canvas_uid: '300', name: 'Lead TA') }
+
+      before do
+        UserToCourse.create!(user: leadta, course: course, role: 'leadta')
+        student_enrollment
+        session[:user_id] = leadta.canvas_uid
+        leadta.lms_credentials.create!(
+          lms_name: 'canvas',
+          token: 'fake_token',
+          refresh_token: 'fake_refresh_token',
+          expire_time: 1.hour.from_now
+        )
+      end
+
+      it 'successfully enables allow_extended_requests' do
+        patch :toggle_allow_extended_requests, params: {
+          course_id: course.id,
+          id: student_enrollment.id,
+          allow_extended_requests: true
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(student_enrollment.reload.allow_extended_requests).to be true
+      end
+    end
+
+    context 'when user is a regular TA' do
+      let(:ta_user) { User.create!(email: 'ta@example.com', canvas_uid: '400', name: 'TA') }
+
+      before do
+        UserToCourse.create!(user: ta_user, course: course, role: 'ta')
+        student_enrollment
+        session[:user_id] = ta_user.canvas_uid
+        ta_user.lms_credentials.create!(
+          lms_name: 'canvas',
+          token: 'fake_token',
+          refresh_token: 'fake_refresh_token',
+          expire_time: 1.hour.from_now
+        )
+      end
+
+      it 'returns forbidden status' do
+        patch :toggle_allow_extended_requests, params: {
+          course_id: course.id,
+          id: student_enrollment.id,
+          allow_extended_requests: true
+        }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'does not update the enrollment' do
+        patch :toggle_allow_extended_requests, params: {
+          course_id: course.id,
+          id: student_enrollment.id,
+          allow_extended_requests: true
+        }
+
+        expect(student_enrollment.reload.allow_extended_requests).to be false
+      end
+    end
+
     context 'when user is a student' do
       before do
         student_enrollment
@@ -83,7 +146,6 @@ RSpec.describe UserToCoursesController, type: :controller do
         }
 
         expect(response).to have_http_status(:forbidden)
-        expect(response.parsed_body['redirect_to']).to be_present
       end
 
       it 'does not update the enrollment' do

--- a/spec/factories/user_to_course.rb
+++ b/spec/factories/user_to_course.rb
@@ -8,6 +8,14 @@ FactoryBot.define do
       role { 'teacher' }
     end
 
+    trait :as_leadta do
+      role { 'leadta' }
+    end
+
+    trait :as_ta do
+      role { 'ta' }
+    end
+
     trait :as_student do
       role { 'student' }
     end

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -1,0 +1,347 @@
+require 'rails_helper'
+
+RSpec.describe CoursePolicy do
+  let(:course) { create(:course) }
+  let(:student_user) { create(:user, :with_canvas_token, courses: [ course ], role: 'student') }
+  let(:ta_user) { create(:user, :with_canvas_token, courses: [ course ], role: 'ta') }
+  let(:leadta_user) { create(:user, :with_canvas_token, courses: [ course ], role: 'leadta') }
+  let(:teacher_user) { create(:user, :with_canvas_token, courses: [ course ], role: 'teacher') }
+  let(:admin_user) { create(:admin, :with_canvas_token) }
+  let(:unenrolled_user) { create(:user, :with_canvas_token) }
+
+  def policy_for(user)
+    CoursePolicy.new(user, course)
+  end
+
+  describe 'role checks' do
+    describe '#site_admin?' do
+      it 'returns true for admin users' do
+        expect(policy_for(admin_user).site_admin?).to be true
+      end
+
+      it 'returns false for non-admin users' do
+        expect(policy_for(student_user).site_admin?).to be false
+        expect(policy_for(teacher_user).site_admin?).to be false
+      end
+    end
+
+    describe '#course_admin?' do
+      it 'returns true for teachers' do
+        expect(policy_for(teacher_user).course_admin?).to be true
+      end
+
+      it 'returns true for lead TAs' do
+        expect(policy_for(leadta_user).course_admin?).to be true
+      end
+
+      it 'returns true for site admins' do
+        expect(policy_for(admin_user).course_admin?).to be true
+      end
+
+      it 'returns false for regular TAs' do
+        expect(policy_for(ta_user).course_admin?).to be false
+      end
+
+      it 'returns false for students' do
+        expect(policy_for(student_user).course_admin?).to be false
+      end
+    end
+
+    describe '#staff?' do
+      it 'returns true for teachers' do
+        expect(policy_for(teacher_user).staff?).to be true
+      end
+
+      it 'returns true for lead TAs' do
+        expect(policy_for(leadta_user).staff?).to be true
+      end
+
+      it 'returns true for regular TAs' do
+        expect(policy_for(ta_user).staff?).to be true
+      end
+
+      it 'returns true for site admins' do
+        expect(policy_for(admin_user).staff?).to be true
+      end
+
+      it 'returns false for students' do
+        expect(policy_for(student_user).staff?).to be false
+      end
+
+      it 'returns false for unenrolled users' do
+        expect(policy_for(unenrolled_user).staff?).to be false
+      end
+    end
+
+    describe '#student?' do
+      it 'returns true for students' do
+        expect(policy_for(student_user).student?).to be true
+      end
+
+      it 'returns false for staff' do
+        expect(policy_for(ta_user).student?).to be false
+        expect(policy_for(teacher_user).student?).to be false
+      end
+    end
+
+    describe '#enrolled?' do
+      it 'returns true for enrolled users' do
+        expect(policy_for(student_user).enrolled?).to be true
+        expect(policy_for(ta_user).enrolled?).to be true
+      end
+
+      it 'returns false for unenrolled users' do
+        expect(policy_for(unenrolled_user).enrolled?).to be false
+      end
+    end
+
+    describe '#view_role' do
+      it 'returns instructor for all staff roles' do
+        expect(policy_for(teacher_user).view_role).to eq('instructor')
+        expect(policy_for(leadta_user).view_role).to eq('instructor')
+        expect(policy_for(ta_user).view_role).to eq('instructor')
+      end
+
+      it 'returns student for students' do
+        expect(policy_for(student_user).view_role).to eq('student')
+      end
+
+      it 'returns nil for unenrolled users' do
+        expect(policy_for(unenrolled_user).view_role).to be_nil
+      end
+    end
+  end
+
+  describe 'course-level permissions' do
+    describe '#can_view_import_page?' do
+      it 'allows any authenticated user' do
+        expect(policy_for(student_user).can_view_import_page?).to be true
+        expect(policy_for(unenrolled_user).can_view_import_page?).to be true
+      end
+
+      it 'disallows nil user' do
+        expect(CoursePolicy.new(nil, course).can_view_import_page?).to be false
+      end
+    end
+
+    describe '#can_create_course?' do
+      it 'allows any authenticated user' do
+        expect(policy_for(student_user).can_create_course?).to be true
+        expect(policy_for(ta_user).can_create_course?).to be true
+      end
+    end
+
+    describe '#can_view_course?' do
+      it 'allows enrolled users' do
+        expect(policy_for(student_user).can_view_course?).to be true
+        expect(policy_for(ta_user).can_view_course?).to be true
+      end
+
+      it 'allows site admins even if not enrolled' do
+        expect(policy_for(admin_user).can_view_course?).to be true
+      end
+
+      it 'disallows unenrolled non-admin users' do
+        expect(policy_for(unenrolled_user).can_view_course?).to be false
+      end
+    end
+
+    describe '#can_edit_course?' do
+      it 'allows teachers' do
+        expect(policy_for(teacher_user).can_edit_course?).to be true
+      end
+
+      it 'allows lead TAs' do
+        expect(policy_for(leadta_user).can_edit_course?).to be true
+      end
+
+      it 'allows site admins' do
+        expect(policy_for(admin_user).can_edit_course?).to be true
+      end
+
+      it 'disallows regular TAs' do
+        expect(policy_for(ta_user).can_edit_course?).to be false
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_edit_course?).to be false
+      end
+    end
+
+    describe '#can_delete_course?' do
+      it 'allows course admins' do
+        expect(policy_for(teacher_user).can_delete_course?).to be true
+        expect(policy_for(leadta_user).can_delete_course?).to be true
+      end
+
+      it 'disallows regular TAs' do
+        expect(policy_for(ta_user).can_delete_course?).to be false
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_delete_course?).to be false
+      end
+    end
+
+    describe '#can_view_enrollments?' do
+      it 'allows all staff' do
+        expect(policy_for(teacher_user).can_view_enrollments?).to be true
+        expect(policy_for(leadta_user).can_view_enrollments?).to be true
+        expect(policy_for(ta_user).can_view_enrollments?).to be true
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_view_enrollments?).to be false
+      end
+    end
+
+    describe '#can_sync_assignments?' do
+      it 'allows all staff' do
+        expect(policy_for(teacher_user).can_sync_assignments?).to be true
+        expect(policy_for(ta_user).can_sync_assignments?).to be true
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_sync_assignments?).to be false
+      end
+    end
+
+    describe '#can_sync_enrollments?' do
+      it 'allows all staff' do
+        expect(policy_for(teacher_user).can_sync_enrollments?).to be true
+        expect(policy_for(ta_user).can_sync_enrollments?).to be true
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_sync_enrollments?).to be false
+      end
+    end
+  end
+
+  describe 'request permissions' do
+    describe '#can_view_requests?' do
+      it 'allows enrolled users' do
+        expect(policy_for(student_user).can_view_requests?).to be true
+        expect(policy_for(ta_user).can_view_requests?).to be true
+      end
+
+      it 'allows site admins' do
+        expect(policy_for(admin_user).can_view_requests?).to be true
+      end
+
+      it 'disallows unenrolled users' do
+        expect(policy_for(unenrolled_user).can_view_requests?).to be false
+      end
+    end
+
+    describe '#can_create_request?' do
+      it 'allows enrolled users' do
+        expect(policy_for(student_user).can_create_request?).to be true
+        expect(policy_for(ta_user).can_create_request?).to be true
+      end
+    end
+
+    describe '#can_create_request_for_student?' do
+      it 'allows staff' do
+        expect(policy_for(teacher_user).can_create_request_for_student?).to be true
+        expect(policy_for(ta_user).can_create_request_for_student?).to be true
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_create_request_for_student?).to be false
+      end
+    end
+
+    describe '#can_cancel_request?' do
+      it 'allows all staff' do
+        expect(policy_for(teacher_user).can_cancel_request?).to be true
+        expect(policy_for(leadta_user).can_cancel_request?).to be true
+        expect(policy_for(ta_user).can_cancel_request?).to be true
+      end
+
+      it 'allows site admins' do
+        expect(policy_for(admin_user).can_cancel_request?).to be true
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_cancel_request?).to be false
+      end
+    end
+
+    describe '#can_approve_or_deny_requests?' do
+      it 'allows all staff including regular TAs' do
+        expect(policy_for(teacher_user).can_approve_or_deny_requests?).to be true
+        expect(policy_for(leadta_user).can_approve_or_deny_requests?).to be true
+        expect(policy_for(ta_user).can_approve_or_deny_requests?).to be true
+      end
+
+      it 'allows site admins' do
+        expect(policy_for(admin_user).can_approve_or_deny_requests?).to be true
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_approve_or_deny_requests?).to be false
+      end
+    end
+  end
+
+  describe 'settings permissions (course admin only)' do
+    describe '#can_manage_settings?' do
+      it 'allows teachers' do
+        expect(policy_for(teacher_user).can_manage_settings?).to be true
+      end
+
+      it 'allows lead TAs' do
+        expect(policy_for(leadta_user).can_manage_settings?).to be true
+      end
+
+      it 'allows site admins' do
+        expect(policy_for(admin_user).can_manage_settings?).to be true
+      end
+
+      it 'disallows regular TAs' do
+        expect(policy_for(ta_user).can_manage_settings?).to be false
+      end
+
+      it 'disallows students' do
+        expect(policy_for(student_user).can_manage_settings?).to be false
+      end
+    end
+
+    describe '#can_manage_form_settings?' do
+      it 'allows course admins only' do
+        expect(policy_for(teacher_user).can_manage_form_settings?).to be true
+        expect(policy_for(leadta_user).can_manage_form_settings?).to be true
+        expect(policy_for(ta_user).can_manage_form_settings?).to be false
+        expect(policy_for(student_user).can_manage_form_settings?).to be false
+      end
+    end
+
+    describe '#can_manage_extended_circumstances?' do
+      it 'allows course admins only' do
+        expect(policy_for(teacher_user).can_manage_extended_circumstances?).to be true
+        expect(policy_for(leadta_user).can_manage_extended_circumstances?).to be true
+        expect(policy_for(ta_user).can_manage_extended_circumstances?).to be false
+        expect(policy_for(student_user).can_manage_extended_circumstances?).to be false
+      end
+    end
+
+    describe '#can_toggle_assignment?' do
+      it 'allows course admins only' do
+        expect(policy_for(teacher_user).can_toggle_assignment?).to be true
+        expect(policy_for(leadta_user).can_toggle_assignment?).to be true
+        expect(policy_for(ta_user).can_toggle_assignment?).to be false
+        expect(policy_for(student_user).can_toggle_assignment?).to be false
+      end
+    end
+  end
+
+  describe 'without a course' do
+    it 'handles nil course gracefully' do
+      policy = CoursePolicy.new(student_user, nil)
+      expect(policy.enrolled?).to be false
+      expect(policy.staff?).to be false
+      expect(policy.can_view_import_page?).to be true
+    end
+  end
+end


### PR DESCRIPTION
# Centralize RBAC Permissions with CoursePolicy and Authorization Concern

This PR replaces decentralized `@role` string comparisons scattered across controllers and views with a dedicated `CoursePolicy` class and `Authorization` controller concern, removing reliance on external gems while implementing modern RBAC practices.

# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Previously, authorization was handled ad-hoc throughout controllers and views using `@role == 'instructor'` string comparisons. This approach was fragile, untested, and didn't correctly handle all role types (e.g., `leadta` was not recognized as a staff role in several places).

**New files:**
- **`app/policies/course_policy.rb`** — Centralized RBAC policy class defining four role tiers:
  - `site_admin`: `User.admin?` flag, can do everything
  - `course_admin`: teacher or leadta enrollment, can manage everything in a course
  - `staff` (TA): regular TA, can view everything, approve/deny requests, sync assignments/enrollments
  - `student`: can only manage their own extensions
- **`app/controllers/concerns/authorization.rb`** — Controller concern providing `current_policy`, `authorize!`, and `deny_access!` helpers with consistent redirect/JSON error behavior

**Key behavioral changes:**

| Action | Before | After |
|--------|--------|-------|
| Course/form settings | Any "instructor" (teacher or TA) | Course admins only (teacher/leadta) |
| Toggle assignments | Any "instructor" | Course admins only |
| Approve/deny requests | Any "instructor" | All staff (teacher/leadta/ta) |
| Cancel/delete requests | Any user | Staff only (students blocked) |
| Sync assignments/enrollments | No role check | Staff only |
| View enrollments | Any "instructor" | All staff |
| `leadta` role | Not handled (returned nil in some paths) | Treated as staff + course_admin |
| Auth failure redirect | `courses_path` | `course_path(@course)` when course is known |

The `ensure_instructor_role` method in `ApplicationController` now delegates to `authorize! :staff?` rather than checking `@role == 'instructor'`. The `user_role` method on `Course` now uses `UserToCourse.staff_roles` to correctly include `leadta` in the staff check.

# Testing

Added 58 comprehensive unit tests in `spec/policies/course_policy_spec.rb` covering every permission method for all role combinations (site_admin, teacher, leadta, ta, student, unenrolled).

Updated existing controller specs to use real database enrollments instead of `allow_any_instance_of` stubs, making tests more accurate and resilient. Added new controller-level tests for:
- Regular TAs being denied access to course/form settings
- Students being denied access to enrollments, sync endpoints, and assignment toggling
- Lead TAs being granted course admin privileges (toggle extended circumstances)

All 448 existing tests continue to pass.

# Documentation

No external documentation required. The `CoursePolicy` class is thoroughly documented inline with role definitions and usage examples.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/CzhDCbcFNgFw/implementations/PmGMBwcHrcgB) | [App Preview](https://www.superconductor.com/tickets/CzhDCbcFNgFw/implementations/PmGMBwcHrcgB/preview) | [Guided Review](https://www.superconductor.com/tickets/CzhDCbcFNgFw/implementations/PmGMBwcHrcgB?tab=guided_review)

<!-- created-by-superconductor -->