### PR TITLE
Add API parameters to Canvas Calls

### DIFF
--- a/app/facades/canvas_facade.rb
+++ b/app/facades/canvas_facade.rb
@@ -221,7 +221,7 @@ class CanvasFacade < LmsFacade
   # @return [Faraday::Response] single page of assignments in the course.
   def get_assignments(course_id)
     @canvas_conn.get("courses/#{course_id}/assignments", {
-      'include[]' => [ 'all_dates', 'overrides' ],
+      'include' => [ 'all_dates', 'overrides' ],
       'override_assignment_dates' => false,
       'per_page' => 100
     })

--- a/app/facades/canvas_facade.rb
+++ b/app/facades/canvas_facade.rb
@@ -190,6 +190,7 @@ class CanvasFacade < LmsFacade
       per_page: 100,
       'include[]': 'term'
     })
+    # TODO: Remove duplication of courses with multiple roles (e.g. teacher + ta)
     teacher_courses + ta_courses
   end
 
@@ -220,7 +221,8 @@ class CanvasFacade < LmsFacade
   # @return [Faraday::Response] single page of assignments in the course.
   def get_assignments(course_id)
     @canvas_conn.get("courses/#{course_id}/assignments", {
-      'include[]' => 'all_dates',
+      'include[]' => [ 'all_dates', 'overrides' ],
+      'override_assignment_dates' => false,
       'per_page' => 100
     })
   end
@@ -252,7 +254,11 @@ class CanvasFacade < LmsFacade
   # @param  [Integer] assignmentId the id of the assignment to fetch.
   # @return [Faraday::Response] information about the requested assignment.
   def get_assignment(courseId, assignmentId)
-    @canvas_conn.get("courses/#{courseId}/assignments/#{assignmentId}")
+    @canvas_conn.get("courses/#{courseId}/assignments/#{assignmentId}", {
+      'include[]' => 'overrides',
+      'all_dates' => true,
+      'override_assignment_dates' => false
+    })
   end
 
   ##

--- a/spec/facades/canvas_facade_spec.rb
+++ b/spec/facades/canvas_facade_spec.rb
@@ -56,10 +56,11 @@ describe CanvasFacade do
       end
     end
 
+    # TODO: Verify min set of parameters needed, and that override_assignment_dates is being passed correctly, along with overrides include parameter.
     it 'makes a request with correct parameters' do
       result = facade.get_assignments(external_course_id)
       params = Rack::Utils.parse_query(URI(result.env.url).query)
-      expect(params['include[]']).to eq('all_dates')
+      expect(params['include[]']).to include('all_dates')
       expect(params['per_page']).to eq('100')
       expect(result.status).to eq(200)
       expect(result.body).to eq(assignments_response)


### PR DESCRIPTION
Always fetch the overrides, base_date and try to tell canvas not to give incorrect due dates