### PR TITLE
Investigate and fix incorrect Canvas assignment due dates, add logging for overrides

### DIFF
--- a/app/jobs/sync_all_course_assignments_job.rb
+++ b/app/jobs/sync_all_course_assignments_job.rb
@@ -1,6 +1,12 @@
 class SyncAllCourseAssignmentsJob < ApplicationJob
   queue_as :default
 
+  # Canvas omits the `all_dates` array (and therefore the base date) once an
+  # assignment has more than this many dates/overrides. Without a base date we
+  # cannot trust the root-level due date Canvas returns, since it may be derived
+  # from an override and be later than the real assignment due date.
+  OVERRIDE_DATE_LIMIT = 25
+
   def perform(course_to_lms_id, sync_user_id)
     # TODO: Replace this with just the course idea, then find all linked LMS.
     course_to_lms = CourseToLms.find(course_to_lms_id)
@@ -47,9 +53,15 @@ class SyncAllCourseAssignmentsJob < ApplicationJob
 
     # Use shared LmsAssignment to populate Assignment
     assignment.name = lms_assignment.name
-    assignment.due_date = lms_assignment.due_date
-    assignment.late_due_date = lms_assignment.late_due_date
     assignment.external_assignment_id = lms_assignment.id
+
+    if skip_due_date_update?(assignment, lms_assignment)
+      log_skipped_due_date_update(course_to_lms, assignment, lms_assignment)
+    else
+      log_due_date_update(course_to_lms, assignment, lms_assignment)
+      assignment.due_date = lms_assignment.due_date
+      assignment.late_due_date = lms_assignment.late_due_date
+    end
 
     if assignment.new_record?
       results[:added_assignments] += 1
@@ -59,5 +71,43 @@ class SyncAllCourseAssignmentsJob < ApplicationJob
       results[:unchanged_assignments] += 1
     end
     assignment.save!
+  end
+
+  # Don't overwrite due dates on a subsequent sync when Canvas can't give us a
+  # reliable base date. With >= OVERRIDE_DATE_LIMIT overrides and no base_date,
+  # the incoming dates may be derived from an override and be too late, so we
+  # keep the previously-synced values instead of clobbering them.
+  def skip_due_date_update?(assignment, lms_assignment)
+    !assignment.new_record? &&
+      lms_assignment.overrides_count >= OVERRIDE_DATE_LIMIT &&
+      !lms_assignment.base_date?
+  end
+
+  def log_skipped_due_date_update(course_to_lms, assignment, lms_assignment)
+    Rails.logger.warn(
+      '[SyncAssignments] Skipping due date update for assignment ' \
+      "#{lms_assignment.id} (course_to_lms=#{course_to_lms.id}): " \
+      "#{lms_assignment.overrides_count} overrides and no base_date present. " \
+      "Keeping stored due_date=#{assignment.due_date.inspect}, " \
+      "late_due_date=#{assignment.late_due_date.inspect}; Canvas reported " \
+      "due_date=#{lms_assignment.due_date.inspect}, " \
+      "late_due_date=#{lms_assignment.late_due_date.inspect}."
+    )
+  end
+
+  # Log the date signals for assignments that carry overrides so we can review
+  # cases where the synced due date still looks wrong.
+  def log_due_date_update(course_to_lms, assignment, lms_assignment)
+    return unless lms_assignment.overrides_count.positive?
+
+    Rails.logger.info(
+      '[SyncAssignments] Updating due dates for assignment ' \
+      "#{lms_assignment.id} (course_to_lms=#{course_to_lms.id}): " \
+      "overrides=#{lms_assignment.overrides_count}, " \
+      "base_date_present=#{lms_assignment.base_date?}, due_date " \
+      "#{assignment.due_date.inspect} -> #{lms_assignment.due_date.inspect}, " \
+      "late_due_date #{assignment.late_due_date.inspect} -> " \
+      "#{lms_assignment.late_due_date.inspect}."
+    )
   end
 end

--- a/lib/lmss/base_assignment.rb
+++ b/lib/lmss/base_assignment.rb
@@ -4,5 +4,13 @@ module Lmss
     def name = raise(NotImplementedError)
     def due_date = raise(NotImplementedError)
     def late_due_date = raise(NotImplementedError)
+
+    # Number of per-student/section date overrides on this assignment.
+    # Defaults to 0 for LMSes that do not expose overrides.
+    def overrides_count = 0
+
+    # Whether the LMS returned an explicit base (non-override) due date.
+    # Defaults to true for LMSes without a base/override date distinction.
+    def base_date? = true
   end
 end

--- a/lib/lmss/canvas/assignment.rb
+++ b/lib/lmss/canvas/assignment.rb
@@ -1,13 +1,24 @@
 module Lmss
   module Canvas
     class Assignment < BaseAssignment
-      attr_reader :id, :name, :due_date, :late_due_date
+      attr_reader :id, :name, :due_date, :late_due_date, :overrides_count
 
       def initialize(data)
         @id = data['id']
         @name = data['name']
         @due_date = extract_date_field(data, 'due_at')
         @late_due_date = extract_date_field(data, 'lock_at')
+        @base_date_present = data['base_date'].present?
+        @overrides_count = Array(data['overrides']).size
+      end
+
+      # Whether Canvas returned an explicit base (non-override) date for this
+      # assignment. Canvas omits the `all_dates` array (the source of the base
+      # date) once an assignment has more than ~25 dates, in which case the
+      # due/late dates fall back to the root-level fields, which Canvas may
+      # populate from an override and therefore report as too late.
+      def base_date?
+        @base_date_present
       end
 
       private

--- a/spec/jobs/sync_all_course_assignments_job_spec.rb
+++ b/spec/jobs/sync_all_course_assignments_job_spec.rb
@@ -114,6 +114,95 @@ RSpec.describe SyncAllCourseAssignmentsJob, type: :job do
       end
     end
 
+    context 'when assignment has many overrides and no base_date' do
+      let(:overrides) { Array.new(25) { |i| { 'id' => i, 'due_at' => '2025-12-31T23:59:00Z' } } }
+      let(:canvas_assignments) do
+        [
+          build_canvas_assignment(
+            'id' => '123',
+            'name' => 'Assignment with many overrides',
+            # Root-level due date Canvas may have derived from an override.
+            'due_at' => '2025-12-31T23:59:00Z',
+            'lock_at' => '2026-01-05T23:59:00Z',
+            'base_date' => nil,
+            'overrides' => overrides
+          )
+        ]
+      end
+
+      it 'does not overwrite due dates on a subsequent sync' do
+        existing_assignment = create(:assignment,
+          course_to_lms: course_to_lms,
+          external_assignment_id: '123',
+          name: 'Old Name',
+          due_date: DateTime.parse('2025-01-15T23:59:00Z'),
+          late_due_date: DateTime.parse('2025-01-20T23:59:00Z')
+        )
+
+        described_class.perform_now(course_to_lms.id, sync_user.id)
+
+        existing_assignment.reload
+        # Name still syncs, but the suspect due dates are preserved.
+        expect(existing_assignment.name).to eq('Assignment with many overrides')
+        expect(existing_assignment.due_date).to eq(DateTime.parse('2025-01-15T23:59:00Z'))
+        expect(existing_assignment.late_due_date).to eq(DateTime.parse('2025-01-20T23:59:00Z'))
+      end
+
+      it 'still sets due dates when the assignment is new' do
+        described_class.perform_now(course_to_lms.id, sync_user.id)
+
+        assignment = Assignment.find_by(external_assignment_id: '123')
+        expect(assignment.due_date).to eq(DateTime.parse('2025-12-31T23:59:00Z'))
+        expect(assignment.late_due_date).to eq(DateTime.parse('2026-01-05T23:59:00Z'))
+      end
+
+      it 'logs that the due date update was skipped' do
+        create(:assignment,
+          course_to_lms: course_to_lms,
+          external_assignment_id: '123',
+          due_date: DateTime.parse('2025-01-15T23:59:00Z')
+        )
+
+        expect(Rails.logger).to receive(:warn).with(/Skipping due date update/)
+
+        described_class.perform_now(course_to_lms.id, sync_user.id)
+      end
+    end
+
+    context 'when assignment has many overrides but a base_date is present' do
+      let(:overrides) { Array.new(30) { |i| { 'id' => i, 'due_at' => '2025-12-31T23:59:00Z' } } }
+      let(:canvas_assignments) do
+        [
+          build_canvas_assignment(
+            'id' => '123',
+            'name' => 'Assignment with base_date and overrides',
+            'due_at' => nil,
+            'lock_at' => nil,
+            'base_date' => {
+              'due_at' => '2025-03-15T23:59:00Z',
+              'lock_at' => '2025-03-20T23:59:00Z'
+            },
+            'overrides' => overrides
+          )
+        ]
+      end
+
+      it 'updates due dates from the base_date' do
+        existing_assignment = create(:assignment,
+          course_to_lms: course_to_lms,
+          external_assignment_id: '123',
+          due_date: DateTime.parse('2025-01-15T23:59:00Z'),
+          late_due_date: DateTime.parse('2025-01-20T23:59:00Z')
+        )
+
+        described_class.perform_now(course_to_lms.id, sync_user.id)
+
+        existing_assignment.reload
+        expect(existing_assignment.due_date).to eq(DateTime.parse('2025-03-15T23:59:00Z'))
+        expect(existing_assignment.late_due_date).to eq(DateTime.parse('2025-03-20T23:59:00Z'))
+      end
+    end
+
     context 'when sync_user is not staff' do
       let(:student_user) { course.students.first }
 

--- a/spec/support/canvas_spec_helpers.rb
+++ b/spec/support/canvas_spec_helpers.rb
@@ -15,7 +15,13 @@ module CanvasSpecHelpers
 
     assignment_data = defaults.merge(attrs.transform_keys(&:to_s))
 
-    assignment_data['base_date'] ||= derive_base_date(assignment_data)
+    # Only derive a base_date when the caller didn't supply one. Passing an
+    # explicit `base_date: nil` lets specs model the case where Canvas omits the
+    # base date (e.g. an assignment with many overrides) while still returning a
+    # root-level due date.
+    unless assignment_data.key?('base_date')
+      assignment_data['base_date'] = derive_base_date(assignment_data)
+    end
 
     Lmss::Canvas::Assignment.new(assignment_data)
   end


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Canvas omits the `all_dates` array (the source of the base due date) from its API response when an assignment has more than ~25 overrides. Without a base date, the sync was falling back to the root-level `due_at`/`lock_at` fields, which Canvas can populate from an override — resulting in due dates that are later than the real assignment due date.

**Root cause fix:** Skip overwriting `due_date` and `late_due_date` on subsequent syncs when an assignment has ≥ 25 overrides and no explicit base date is present. New assignments are unaffected (dates are always set on first sync), and non-Canvas LMS integrations (e.g. Gradescope) are unaffected via safe defaults in `BaseAssignment`.

**Key changes:**
- `SyncAllCourseAssignmentsJob`: Added `OVERRIDE_DATE_LIMIT = 25` constant and `skip_due_date_update?` guard. Name and other fields continue to sync normally even when date updates are skipped.
- `Lmss::Canvas::Assignment`: Exposes `overrides_count` (size of the `overrides` array) and `base_date?` (whether Canvas returned an explicit base date).
- `Lmss::BaseAssignment`: Added default implementations (`overrides_count = 0`, `base_date? = true`) so other LMS integrations are never affected by the guard.
- **Logging**: A `warn` is emitted when a due date update is skipped (showing stored vs. Canvas-reported dates). An `info` is emitted for any override-bearing assignment whose dates *are* updated, so we can continue monitoring for incorrect dates.
- `CanvasSpecHelpers`: Fixed `build_canvas_assignment` so passing `base_date: nil` correctly models Canvas omitting the base date, rather than deriving one.

# Testing

Added RSpec contexts to `sync_all_course_assignments_job_spec.rb` covering:
- **Many overrides + no base_date**: Existing assignment's due dates are preserved on re-sync; name still updates. New assignment still gets dates set. Skip is logged with a `warn`.
- **Many overrides + base_date present**: Due dates are correctly updated from the base date even when override count is high.

All new and existing specs should be run against a database-backed environment before merging.

# Documentation

No additional documentation required.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/nGndqzfhNHBz/implementations/gtb7rh7QkfpB) | [App Preview](https://www.superconductor.com/tickets/nGndqzfhNHBz/implementations/gtb7rh7QkfpB/preview) | [Guided Review](https://www.superconductor.com/tickets/nGndqzfhNHBz/implementations/gtb7rh7QkfpB?tab=guided_review)

<!-- created-by-superconductor -->