### PR TITLE
Add Page Size Selector to Requests view

### DIFF
--- a/app/javascript/controllers/requests_controller.js
+++ b/app/javascript/controllers/requests_controller.js
@@ -25,6 +25,8 @@ export default class extends Controller {
                 ordering: true,
                 info: true,
                 responsive: true,
+                pageLength: 50,
+                lengthMenu: [[25, 50, 100, 200, -1], [25, 50, 100, 200, "All"]],
                 columnDefs: [
                     { orderable: false, targets: 'no-sort' },
                     { type: "date", targets: [5, 6, 7] },
@@ -33,6 +35,7 @@ export default class extends Controller {
                 order: [[5, "asc"]],
                 layout: {
                     topStart: {
+                        pageLength: {},
                         buttons: [
                             {
                                 extend: 'colvis',

--- a/app/javascript/controllers/requests_controller.js
+++ b/app/javascript/controllers/requests_controller.js
@@ -35,7 +35,6 @@ export default class extends Controller {
                 order: [[5, "asc"]],
                 layout: {
                     topStart: {
-                        pageLength: {},
                         buttons: [
                             {
                                 extend: 'colvis',
@@ -66,7 +65,8 @@ export default class extends Controller {
                                         : '<i class="fas fa-edit me-1"></i>Batch Edit';
                                 }
                             }
-                        ]
+                        ],
+                        pageLength: {},
                     }
                 }
             });


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Updates the pending requests (instructor index) table to improve usability for larger datasets:

- Sets the default page length to **50** rows (previously defaulted to DataTables' built-in 10)
- Adds a **page size selector** with options: 25, 50, 100, 200, All
- Re-adds the `pageLength` feature to the `topStart` layout cell so the selector renders alongside the existing Columns/Batch Edit buttons

All changes are client-side only in `requests_controller.js` — no Ruby or database changes needed.

> **Note for reviewers:** The page-size dropdown and the Columns/Batch Edit buttons now share the top-left cell. Worth a quick visual check that the layout looks clean, though DataTables-bs5 handles this automatically.

# Testing

Manually verify on the pending requests view that:
1. The table defaults to 50 rows per page on load
2. The page-size dropdown appears and offers 25, 50, 100, 200, and All options
3. Selecting a different page size updates the table correctly
4. The existing Columns and Batch Edit buttons still render and function correctly alongside the new dropdown

# Documentation

No documentation changes required.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/jHrwj8WGBP6C/implementations/7PfGTkJCjckp) | [App Preview](https://www.superconductor.com/tickets/jHrwj8WGBP6C/implementations/7PfGTkJCjckp/preview) | [Guided Review](https://www.superconductor.com/tickets/jHrwj8WGBP6C/implementations/7PfGTkJCjckp?tab=guided_review)

<!-- created-by-superconductor -->