### PR TITLE
Set up local exception tracking engine and UI as Sentry cannot be used for the public app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,13 +40,9 @@ SMTP_PORT=465
 SMTP_SSL=true
 SMTP_USERNAME=
 
-# Exception tracking dashboard (rails_error_dashboard), mounted at /admin/red.
-# Access is restricted to logged-in app admins via `config.authenticate_with`
-# in config/initializers/rails_error_dashboard.rb, so HTTP Basic Auth is
-# bypassed and these are NOT required. They only act as a fallback if that
-# custom auth is ever removed; leave unset to use the safe generated defaults.
-# ERROR_DASHBOARD_USER=
-# ERROR_DASHBOARD_PASSWORD=
+# Exception tracking dashboard (rails_error_dashboard) is mounted at /admin/red
+# and gated entirely by the app's admin users (config.authenticate_with in
+# config/initializers/rails_error_dashboard.rb). It needs no env vars.
 
 ### DEPRECATED ENVIRONMENT VARIABLES
 # Set this is you return to using encrypted credentials

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,14 @@ SMTP_PORT=465
 SMTP_SSL=true
 SMTP_USERNAME=
 
+# Exception tracking dashboard (rails_error_dashboard), mounted at /admin/red.
+# Access is restricted to logged-in app admins via `config.authenticate_with`
+# in config/initializers/rails_error_dashboard.rb, so HTTP Basic Auth is
+# bypassed and these are NOT required. They only act as a fallback if that
+# custom auth is ever removed; leave unset to use the safe generated defaults.
+# ERROR_DASHBOARD_USER=
+# ERROR_DASHBOARD_PASSWORD=
+
 ### DEPRECATED ENVIRONMENT VARIABLES
 # Set this is you return to using encrypted credentials
 RAILS_MASTER_KEY=

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,11 @@ gem 'lms-api'
 gem 'sentry-ruby'
 gem 'sentry-rails'
 
+# Self-hosted exception tracking for the public app (Sentry alternative).
+# Mounts a dashboard UI and captures exceptions into our own database.
+# https://github.com/AnjanJ/rails_error_dashboard
+gem 'rails_error_dashboard'
+
 gem 'json'
 
 # Used to make http requests.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
@@ -221,6 +221,8 @@ GEM
       reline
     globalid (1.3.0)
       activesupport (>= 6.1)
+    groupdate (6.8.0)
+      activesupport (>= 7.2)
     guard (2.20.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -362,6 +364,10 @@ GEM
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
     ostruct (0.6.3)
+    pagy (43.5.6)
+      json
+      uri
+      yaml
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -427,6 +433,11 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_error_dashboard (0.8.2)
+      concurrent-ruby (~> 1.3.0, < 1.3.7)
+      groupdate (~> 6.0)
+      pagy (~> 43.0)
+      rails (>= 7.0.0)
     railties (7.2.3.1)
       actionpack (= 7.2.3.1)
       activesupport (= 7.2.3.1)
@@ -603,6 +614,7 @@ GEM
     win32ole (1.9.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yaml (0.4.0)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -651,6 +663,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 7.2.3.1)
   rails-controller-testing (~> 1.0)
+  rails_error_dashboard
   rspec-rails
   rspec-retry
   rubocop

--- a/config/initializers/rails_error_dashboard.rb
+++ b/config/initializers/rails_error_dashboard.rb
@@ -1,0 +1,405 @@
+# frozen_string_literal: true
+
+RailsErrorDashboard.configure do |config|
+  # ============================================================================
+  # AUTHENTICATION (Always Required - Cannot Be Disabled)
+  # ============================================================================
+
+  # We authenticate against the app's own admin users (see `authenticate_with`
+  # below), so the built-in HTTP Basic Auth credentials are not used. They are
+  # still set to non-default values so the gem's production validation passes
+  # and Basic Auth can never be relied on by accident.
+  config.dashboard_username = ENV.fetch("ERROR_DASHBOARD_USER", "flextensions-red")
+  config.dashboard_password = ENV.fetch("ERROR_DASHBOARD_PASSWORD", SecureRandom.hex(32))
+
+  # === Custom Authentication (optional) ===
+  # Use your app's existing auth instead of HTTP Basic Auth.
+  # The lambda runs in controller context (via instance_exec), giving access to
+  # warden, session, request, params, cookies, redirect_to, etc.
+  # Return truthy to allow access, falsy to deny (403 Forbidden).
+  #
+  # NOTE: Devise helpers (current_user, authenticate_user!) are NOT available
+  # because the engine controller inherits from ActionController::Base, not your
+  # app's ApplicationController. Use `warden` directly instead.
+  #
+  # Devise/Warden example (recommended):
+  #   config.authenticate_with = -> { warden.authenticated? }
+  #
+  # Warden with redirect to login:
+  #   config.authenticate_with = -> {
+  #     if warden.authenticated?
+  #       true
+  #     else
+  #       redirect_to main_app.new_user_session_path, allow_other_host: true
+  #     end
+  #   }
+  #
+  # Session-based example:
+  #   config.authenticate_with = -> { session[:dashboard_admin] == true }
+  #
+  # When nil (default), HTTP Basic Auth above is used instead.
+  #
+  # Flextensions integration: gate the dashboard behind the same admin users
+  # that protect Blazer (see ApplicationController#require_admin). The engine
+  # controller inherits from ActionController::Base, so `current_user` is not
+  # available here — we resolve the logged-in user from the session the same way
+  # ApplicationController#current_user does and require the `admin` flag.
+  config.authenticate_with = lambda do
+    user = User.find_by(canvas_uid: session[:user_id])
+    user.present? && user.admin?
+  end
+
+  # ============================================================================
+  # CORE FEATURES (Always Enabled)
+  # ============================================================================
+
+  # Error capture via middleware and Rails.error subscriber
+  config.enable_middleware = true
+  config.enable_error_subscriber = true
+
+  # User model for error associations
+  config.user_model = "User"
+
+  # Error retention policy (days to keep errors before automatic deletion)
+  # Set to nil to keep errors forever (not recommended for production)
+  # Run cleanup manually: rails error_dashboard:retention_cleanup
+  # Or schedule the job: RailsErrorDashboard::RetentionCleanupJob.perform_later
+  config.retention_days = 90
+
+  # ============================================================================
+  # NOTIFICATION SETTINGS
+  # ============================================================================
+  # Configure which notification channels you want to use.
+  # You can enable/disable any of these at any time by changing true/false.
+
+  # Slack Notifications - DISABLED
+  # To enable: Set config.enable_slack_notifications = true and configure webhook URL
+  config.enable_slack_notifications = false
+  # config.slack_webhook_url = ENV["SLACK_WEBHOOK_URL"]
+
+  # Email Notifications - DISABLED
+  # To enable: Set config.enable_email_notifications = true and configure recipients
+  config.enable_email_notifications = false
+  # config.notification_email_recipients = ENV.fetch("ERROR_NOTIFICATION_EMAILS", "").split(",").map(&:strip)
+  # config.notification_email_from = ENV.fetch("ERROR_NOTIFICATION_FROM", "errors@example.com")
+
+  # Discord Notifications - DISABLED
+  # To enable: Set config.enable_discord_notifications = true and configure webhook URL
+  config.enable_discord_notifications = false
+  # config.discord_webhook_url = ENV["DISCORD_WEBHOOK_URL"]
+
+  # PagerDuty Integration - DISABLED
+  # To enable: Set config.enable_pagerduty_notifications = true and configure integration key
+  config.enable_pagerduty_notifications = false
+  # config.pagerduty_integration_key = ENV["PAGERDUTY_INTEGRATION_KEY"]
+
+  # Generic Webhook Notifications - DISABLED
+  # To enable: Set config.enable_webhook_notifications = true and configure webhook URLs
+  config.enable_webhook_notifications = false
+  # config.webhook_urls = ENV.fetch("WEBHOOK_URLS", "").split(",").map(&:strip).reject(&:empty?)
+
+  # Dashboard base URL (used in notification links)
+  config.dashboard_base_url = ENV["DASHBOARD_BASE_URL"]
+
+  # ============================================================================
+  # PERFORMANCE & SCALABILITY
+  # ============================================================================
+
+  # Async Error Logging - ENABLED
+  # Errors are logged in background jobs — zero impact on request response time.
+  # Default adapter is :async (Rails built-in, no extra infrastructure needed).
+  # Swap to :sidekiq or :solid_queue when you have a background worker running.
+  config.async_logging = true
+  config.async_adapter = :async  # Options: :async (built-in), :sidekiq, :solid_queue
+  # To disable: Set config.async_logging = false
+
+  # Backtrace size limiting (100 lines is industry standard: Rollbar, Airbrake, Bugsnag)
+  config.max_backtrace_lines = 100
+
+  # Error Sampling - DISABLED
+  # All errors are logged (100% sampling rate).
+  # To enable: Set config.sampling_rate < 1.0 (e.g., 0.5 for 50%, 0.1 for 10%)
+  config.sampling_rate = 1.0
+
+  # Ignored exceptions (skip logging these)
+  # config.ignored_exceptions = [
+  #   "ActionController::RoutingError",
+  #   "ActionController::InvalidAuthenticityToken",
+  #   /^ActiveRecord::RecordNotFound/
+  # ]
+
+  # ============================================================================
+  # DATABASE CONFIGURATION
+  # ============================================================================
+
+  # Separate Error Database - DISABLED
+  # Errors are stored in your main application database.
+  # To enable: Set config.use_separate_database = true and configure database.yml
+  # See https://github.com/AnjanJ/rails_error_dashboard/blob/main/docs/guides/DATABASE_OPTIONS.md
+  config.use_separate_database = false
+  # config.database = :error_dashboard
+
+  # ============================================================================
+  # ADVANCED ANALYTICS
+  # ============================================================================
+
+  # Baseline Anomaly Alerts - DISABLED
+  # To enable: Set config.enable_baseline_alerts = true
+  config.enable_baseline_alerts = false
+  # config.baseline_alert_threshold_std_devs = 2.0
+  # config.baseline_alert_severities = [ :critical, :high ]
+  # config.baseline_alert_cooldown_minutes = 120
+
+  # Fuzzy Error Matching - DISABLED
+  # To enable: Set config.enable_similar_errors = true
+  config.enable_similar_errors = false
+
+  # Co-occurring Errors - DISABLED
+  # To enable: Set config.enable_co_occurring_errors = true
+  config.enable_co_occurring_errors = false
+
+  # Error Cascade Detection - DISABLED
+  # To enable: Set config.enable_error_cascades = true
+  config.enable_error_cascades = false
+
+  # Error Correlation Analysis - DISABLED
+  # To enable: Set config.enable_error_correlation = true
+  config.enable_error_correlation = false
+
+  # Platform Comparison - DISABLED
+  # To enable: Set config.enable_platform_comparison = true
+  config.enable_platform_comparison = false
+
+  # Occurrence Pattern Detection - DISABLED
+  # To enable: Set config.enable_occurrence_patterns = true
+  config.enable_occurrence_patterns = false
+
+  # ============================================================================
+  # DEVELOPER TOOLS (NEW!)
+  # ============================================================================
+
+  # Source Code Integration - DISABLED (NEW!)
+  # To enable: Set config.enable_source_code_integration = true
+  config.enable_source_code_integration = false
+
+  # Git Blame Integration - DISABLED (NEW!)
+  # To enable: Set config.enable_git_blame = true (requires Git installed)
+  config.enable_git_blame = false
+
+  # Breadcrumbs - DISABLED
+  # To enable: Set config.enable_breadcrumbs = true
+  config.enable_breadcrumbs = false
+  # config.breadcrumb_buffer_size = 40
+
+  # N+1 Query Detection (analyzes SQL breadcrumbs at display time)
+  # Flags repeated query patterns that suggest missing eager loading
+  config.enable_n_plus_one_detection = true
+  config.n_plus_one_threshold = 3  # Min repetitions to flag (min: 2)
+
+  # System Health Snapshot - DISABLED (NEW!)
+  # To enable: Set config.enable_system_health = true
+  config.enable_system_health = false
+
+  # Swallowed Exception Detection - DISABLED
+  # Requires Ruby 3.3+ (TracePoint(:rescue) not available before 3.3)
+  # To enable: Set config.detect_swallowed_exceptions = true
+  config.detect_swallowed_exceptions = false
+  # config.swallowed_exception_threshold = 0.95
+
+  # Diagnostic Dump - DISABLED
+  # On-demand system state snapshot (rake task + dashboard page)
+  # To enable: Set config.enable_diagnostic_dump = true
+  config.enable_diagnostic_dump = false
+
+  # Process Crash Capture - DISABLED
+  # Captures fatal crashes via at_exit hook (written to disk, imported on next boot)
+  # To enable: Set config.enable_crash_capture = true
+  config.enable_crash_capture = false
+  # config.crash_capture_path = "/tmp/my_app_crashes"
+
+  # Repository settings (auto-detected from git remote, optional override)
+  # config.repository_url = ENV["REPOSITORY_URL"]  # e.g., "https://github.com/user/repo"
+  # config.repository_branch = ENV.fetch("REPOSITORY_BRANCH", "main")  # Default branch
+
+  # ============================================================================
+  # INTERNAL LOGGING (Silent by Default)
+  # ============================================================================
+  # Rails Error Dashboard logging is SILENT by default to keep your logs clean.
+  # Enable only for debugging gem issues or troubleshooting setup.
+
+  # Enable internal logging (default: false - silent)
+  config.enable_internal_logging = false
+
+  # Log level (default: :silent)
+  # Options: :debug, :info, :warn, :error, :silent
+  config.log_level = :silent
+
+  # Example: Enable verbose logging for debugging
+  # config.enable_internal_logging = true
+  # config.log_level = :debug
+
+  # Example: Log only errors (troubleshooting)
+  # config.enable_internal_logging = true
+  # config.log_level = :error
+
+  # ============================================================================
+  # ADDITIONAL CONFIGURATION
+  # ============================================================================
+
+  # Custom severity rules (override automatic severity classification)
+  # config.custom_severity_rules = {
+  #   "PaymentError" => :critical,
+  #   "ValidationError" => :low
+  # }
+
+  # Enhanced metrics (optional)
+  config.app_version = ENV["APP_VERSION"]
+  config.git_sha = ENV["GIT_SHA"]
+  # config.total_users_for_impact = 10000  # For user impact % calculation
+
+  # Git repository URL for clickable commit links and issue tracking
+  # Examples:
+  #   GitHub: "https://github.com/username/repo"
+  #   GitLab: "https://gitlab.com/username/repo"
+  #   Codeberg: "https://codeberg.org/username/repo"
+  # config.git_repository_url = ENV["GIT_REPOSITORY_URL"]
+
+  # ============================================================================
+  # AI HELP (OpenAI / Anthropic)
+  # ============================================================================
+  #
+  # When provider and API key are configured, error detail pages show an
+  # "AI Help" drawer where dashboard users can ask questions about the current
+  # error. Error details, backtrace, and related dashboard context are sent to
+  # the configured provider.
+  #
+  # OpenAI uses the Responses API by default and supports GPT-5 and GPT-4 family
+  # models such as "gpt-5" and "gpt-4.1". Set llm_openai_endpoint to
+  # :chat_completions only if you need the older Chat Completions endpoint.
+  #
+  # config.llm_provider = :openai
+  # config.llm_api_key = -> { Rails.application.credentials.dig(:openai, :api_key) }
+  # config.llm_model = "gpt-5"
+  # config.llm_openai_endpoint = :auto # :auto, :responses, or :chat_completions
+  #
+  # config.llm_provider = :anthropic
+  # config.llm_api_key = -> { Rails.application.credentials.dig(:anthropic, :api_key) }
+  # config.llm_model = "claude-sonnet-4-20250514"
+  #
+  # Shared options:
+  # config.llm_timeout_seconds = 30
+  # config.llm_max_output_tokens = 900
+  # config.llm_system_prompt = "Prefer concise answers with file-level next steps."
+
+  # ============================================================================
+  # OPENTELEMETRY EXPORT (OUTBOUND)
+  # ============================================================================
+  #
+  # Emit gem operations as OpenTelemetry spans so the host's existing
+  # Datadog / Honeycomb / Jaeger / Grafana Tempo pipeline gets a trace
+  # of every error capture. Useful for:
+  #   - Auditing "when did this error get captured?" against deploy events
+  #   - Measuring how much time the gem spends in the capture path
+  #   - Proving the <5ms host-safety budget from operator dashboards
+  #
+  # Emits four spans per error capture:
+  #   rails_error_dashboard.capture_error           — parent, wraps everything
+  #   rails_error_dashboard.breadcrumb_collection   — buffer drain (~µs)
+  #   rails_error_dashboard.system_health_snapshot  — GC.stat etc. (<1ms)
+  #   rails_error_dashboard.notification_dispatch   — Slack/email enqueue
+  #
+  # Disabled by default. Requires the host app to already run OpenTelemetry
+  # (the gem does NOT add an opentelemetry-* runtime dependency). When OTel
+  # is absent, every span call is a zero-overhead no-op.
+  #
+  # config.enable_otel_export = true
+  # config.otel_service_name = "my-app"  # Falls back to application_name when nil
+  #
+  # Per-span opt-out: pass any subset to disable individual span kinds
+  # without code changes. Useful when e.g. notification dispatch is slow due
+  # to outbound HTTP and you don't want it polluting your trace dashboards.
+  #
+  # config.otel_spans = [:capture, :breadcrumbs, :health, :notifications]  # all (default)
+  # config.otel_spans = [:capture]                                          # parent only
+  # config.otel_spans = [:capture, :health]                                 # parent + health
+  #
+  # No PII or request bodies in span attributes — just metadata + timing.
+  # Safe to enable on production OTel pipelines.
+
+  # ============================================================================
+  # STORM PROTECTION (circuit breaker + adaptive sampling) — ON by default
+  # ============================================================================
+  #
+  # When the error rate spikes (bad deploy, dependency outage), storm
+  # protection limits the gem's own database writes so it never amplifies
+  # the incident. Occurrences are ALWAYS counted exactly — only per-event
+  # detail (context payloads, occurrence rows) is sampled under load.
+  #
+  # How it degrades, in order:
+  #   1. Per-fingerprint cap: past N/min, context is shed, then rows sampled
+  #   2. Global breaker: shedding (context off) → open (count-only mode)
+  #   3. Per-error notifications replaced by ONE "storm in progress" message
+  #   4. Counts reconciled onto error records every flush interval
+  #
+  # All thresholds are PER PROCESS (each Puma worker runs its own breaker).
+  #
+  # config.enable_storm_protection = true
+  # config.storm_fingerprint_full_per_minute = 30   # full-fidelity captures per fingerprint/min
+  # config.storm_occurrence_sample_keep_every = 10  # past the cap, keep every Nth occurrence
+  # config.storm_shedding_threshold_per_second = 10 # global rate entering shedding state
+  # config.storm_open_threshold_per_second = 50     # global rate opening the breaker (count-only)
+  # config.storm_cooldown_seconds = 60              # open → half-open probe delay
+  # config.storm_notification = true                # one notification per storm episode
+  #
+  # Always-on issue cap (a storm of NEW critical errors must not open
+  # hundreds of GitHub/Linear issues):
+  # config.auto_issue_rate_limit_count = 5
+  # config.auto_issue_rate_limit_window_minutes = 10
+  #
+  # Calm-weather context economy: an error seen 1000x/day doesn't need 1000
+  # breadcrumb trails. After N full-context captures per fingerprint per day,
+  # context is kept every Mth time (occurrence rows are unaffected):
+  # config.context_sampling_threshold_per_day = 25
+  # config.context_sampling_keep_every = 10
+
+  # ============================================================================
+  # ISSUE TRACKING (GitHub / GitLab / Codeberg / Linear)
+  # ============================================================================
+  #
+  # One switch enables everything: issue creation, auto-create on first
+  # occurrence, lifecycle sync (resolve → close, reopen → reopen), platform
+  # state mirroring (status, assignees, labels), and comment display.
+  #
+  # IMPORTANT: When enabled, the dashboard shows platform state instead of
+  # internal workflow controls:
+  #   - "Mark as Resolved" → replaced by issue open/closed from platform
+  #   - Workflow Status → issue state from platform
+  #   - Assigned To → assignees from platform (with avatars)
+  #   - Priority → labels from platform (with colors)
+  #   - Snooze and Mute remain (no platform equivalent)
+  #
+  # Setup (GitHub/GitLab/Codeberg):
+  #   1. Create a RED bot account on GitHub/GitLab/Codeberg
+  #   2. Generate a token and set RED_BOT_TOKEN env var
+  #   3. Set git_repository_url above (already used for source code linking)
+  #   4. Enable:
+  #
+  # config.enable_issue_tracking = true
+  # config.issue_tracker_token = ENV["RED_BOT_TOKEN"]
+  #
+  # Setup (Linear):
+  #   Linear is not a git forge, so it cannot be auto-detected from
+  #   git_repository_url — set provider and team key explicitly. Issues are
+  #   created in the team matching the key (e.g. "ENG" for ENG-123 issues).
+  #   Generate a personal API key under Settings > Security & access.
+  #
+  # config.enable_issue_tracking = true
+  # config.issue_tracker_provider = :linear
+  # config.issue_tracker_repo = "ENG"                              # Linear team key
+  # config.issue_tracker_token = ENV["RED_BOT_TOKEN"]              # lin_api_... key
+  #
+  # Optional overrides:
+  # config.issue_tracker_labels = ["bug"]                          # Labels added to new issues
+  # config.issue_tracker_auto_create_severities = [:critical, :high]  # Auto-create threshold
+  # config.issue_webhook_secret = ENV["ISSUE_WEBHOOK_SECRET"]      # Enables two-way webhook sync
+end

--- a/config/initializers/rails_error_dashboard.rb
+++ b/config/initializers/rails_error_dashboard.rb
@@ -5,12 +5,13 @@ RailsErrorDashboard.configure do |config|
   # AUTHENTICATION (Always Required - Cannot Be Disabled)
   # ============================================================================
 
-  # We authenticate against the app's own admin users (see `authenticate_with`
-  # below), so the built-in HTTP Basic Auth credentials are not used. They are
-  # still set to non-default values so the gem's production validation passes
-  # and Basic Auth can never be relied on by accident.
-  config.dashboard_username = ENV.fetch("ERROR_DASHBOARD_USER", "flextensions-red")
-  config.dashboard_password = ENV.fetch("ERROR_DASHBOARD_PASSWORD", SecureRandom.hex(32))
+  # Authentication is handled exclusively by the `authenticate_with` lambda
+  # below, which defers to the app's own admin users (the same `admin?` check
+  # that gates Blazer). We intentionally do NOT configure
+  # `dashboard_username`/`dashboard_password`: HTTP Basic Auth is never reached
+  # because the lambda is always set, and when `authenticate_with` is present
+  # the gem's `default_credentials?` check short-circuits to false, so there is
+  # no production boot warning about default credentials.
 
   # === Custom Authentication (optional) ===
   # Use your app's existing auth instead of HTTP Basic Auth.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,4 +68,9 @@ Rails.application.routes.draw do
 
   # This is protected by `require_admin` via blazer.yml
   mount Blazer::Engine, at: "admin/blazer"
+
+  # Self-hosted exception tracking (Sentry alternative for the public app).
+  # Access is restricted to app admins via `config.authenticate_with` in
+  # config/initializers/rails_error_dashboard.rb
+  mount RailsErrorDashboard::Engine, at: "admin/red"
 end

--- a/db/migrate/20260625184347_create_rails_error_dashboard_complete_schema.rails_error_dashboard.rb
+++ b/db/migrate/20260625184347_create_rails_error_dashboard_complete_schema.rails_error_dashboard.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+# Squashed migration for new installations
+# This migration creates the complete Rails Error Dashboard schema in one step.
+#
+# For existing installations, the incremental migrations (20251224-20260106) will run instead.
+# Detection: If error_logs table already exists, this migration is skipped.
+class CreateRailsErrorDashboardCompleteSchema < ActiveRecord::Migration[7.0]
+  def up
+    # Skip if this is an existing installation (error_logs table already exists)
+    # Existing installations will use incremental migrations instead
+    return if table_exists?(:rails_error_dashboard_error_logs)
+
+    # Create applications table
+    create_table :rails_error_dashboard_applications do |t|
+      t.string :name, limit: 255, null: false
+      t.text :description
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+    add_index :rails_error_dashboard_applications, :name, unique: true
+
+    # Create error_logs table with ALL columns from incremental migrations
+    create_table :rails_error_dashboard_error_logs do |t|
+      # Core error fields (from 20251224000001)
+      t.string :error_type, null: false
+      t.text :message, null: false
+      t.text :backtrace
+      t.integer :user_id
+      t.text :request_url
+      t.text :request_params
+      t.text :user_agent
+      t.string :ip_address
+      t.string :platform
+      t.boolean :resolved, null: false, default: false
+      t.text :resolution_comment
+      t.string :resolution_reference
+      t.string :resolved_by_name
+      t.datetime :resolved_at
+      t.datetime :occurred_at, null: false
+
+      # Enhanced tracking fields (from 20251224081522)
+      t.string :error_hash
+      t.datetime :first_seen_at
+      t.datetime :last_seen_at
+      t.integer :occurrence_count, default: 1, null: false
+
+      # Controller/action context (from 20251224101217)
+      t.string :controller_name
+      t.string :action_name
+
+      # Enhanced metrics (from 20251225085859)
+      t.string :app_version
+      t.string :git_sha
+      t.integer :priority_score
+
+      # Similarity tracking (from 20251225093603)
+      t.float :similarity_score
+      t.string :backtrace_signature
+
+      # Workflow fields (from 20251226020000)
+      t.string :status, default: "new"
+      t.string :assigned_to
+      t.datetime :assigned_at
+      t.datetime :snoozed_until
+      t.integer :priority_level, default: 0
+
+      # Application association (from 20260106094233)
+      t.bigint :application_id, null: false
+
+      # Exception cause chain (from 20260220000001)
+      t.text :exception_cause
+
+      # Enriched request context (from 20260220000002)
+      t.string :http_method, limit: 10
+      t.string :hostname, limit: 255
+      t.string :content_type, limit: 100
+      t.integer :request_duration_ms
+
+      # Environment info snapshot (from 20260221000001)
+      t.text :environment_info
+
+      # Auto-reopen tracking (from 20260221000002)
+      t.datetime :reopened_at
+
+      # Breadcrumbs (from 20260303000001)
+      t.text :breadcrumbs
+
+      # System health snapshot (from 20260304000001)
+      t.text :system_health
+
+      # Local variable capture (from 20260306000001)
+      t.text :local_variables
+
+      # Instance variable capture (from 20260306000002)
+      t.text :instance_variables
+
+      # Mute notifications (from 20260323000001)
+      t.boolean :muted, default: false, null: false
+      t.datetime :muted_at
+      t.string :muted_by
+      t.string :muted_reason
+
+      # Issue tracking (GitHub, GitLab, Codeberg)
+      t.string :external_issue_url
+      t.integer :external_issue_number
+      t.string :external_issue_provider, limit: 20
+
+      t.timestamps
+    end
+
+    # Add ALL indexes from incremental migrations
+    # Basic indexes (from 20251224000001)
+    add_index :rails_error_dashboard_error_logs, :error_type
+    add_index :rails_error_dashboard_error_logs, :resolved
+    add_index :rails_error_dashboard_error_logs, :user_id
+    add_index :rails_error_dashboard_error_logs, :occurred_at
+    add_index :rails_error_dashboard_error_logs, :platform
+
+    # Tracking indexes (from 20251224081522)
+    add_index :rails_error_dashboard_error_logs, :error_hash
+    add_index :rails_error_dashboard_error_logs, :first_seen_at
+    add_index :rails_error_dashboard_error_logs, :last_seen_at
+    add_index :rails_error_dashboard_error_logs, :occurrence_count
+
+    # Composite indexes for performance (from 20251225071314)
+    add_index :rails_error_dashboard_error_logs, [ :error_type, :occurred_at ], name: "index_error_logs_on_error_type_and_occurred_at"
+    add_index :rails_error_dashboard_error_logs, [ :resolved, :occurred_at ], name: "index_error_logs_on_resolved_and_occurred_at"
+    add_index :rails_error_dashboard_error_logs, [ :platform, :occurred_at ], name: "index_error_logs_on_platform_and_occurred_at"
+    add_index :rails_error_dashboard_error_logs, [ :error_hash, :resolved, :occurred_at ], name: "index_error_logs_on_hash_resolved_occurred"
+    add_index :rails_error_dashboard_error_logs, [ :controller_name, :action_name, :error_hash ], name: "index_error_logs_on_controller_action_hash"
+
+    # Enhanced metrics indexes (from 20251225085859)
+    add_index :rails_error_dashboard_error_logs, :app_version
+    add_index :rails_error_dashboard_error_logs, :git_sha
+    add_index :rails_error_dashboard_error_logs, :priority_score
+
+    # Similarity tracking indexes (from 20251225093603)
+    add_index :rails_error_dashboard_error_logs, :similarity_score
+    add_index :rails_error_dashboard_error_logs, :backtrace_signature
+
+    # Application indexes (from 20260106094233, 20251229111223)
+    add_index :rails_error_dashboard_error_logs, :application_id
+    add_index :rails_error_dashboard_error_logs, [ :application_id, :occurred_at ], name: "index_error_logs_on_app_occurred"
+    add_index :rails_error_dashboard_error_logs, [ :application_id, :resolved ], name: "index_error_logs_on_app_resolved"
+
+    # Mute index (from 20260323000001)
+    add_index :rails_error_dashboard_error_logs, :muted
+
+    # Workflow indexes (from 20251229111223)
+    add_index :rails_error_dashboard_error_logs, [ :assigned_to, :status, :occurred_at ], name: "index_error_logs_on_assignment_workflow"
+    add_index :rails_error_dashboard_error_logs, [ :priority_level, :resolved, :occurred_at ], name: "index_error_logs_on_priority_resolution"
+    add_index :rails_error_dashboard_error_logs, [ :platform, :status, :occurred_at ], name: "index_error_logs_on_platform_status_time"
+    add_index :rails_error_dashboard_error_logs, [ :app_version, :resolved, :occurred_at ], name: "index_error_logs_on_version_resolution_time"
+
+    # Create error_occurrences table (from 20251225100236)
+    create_table :rails_error_dashboard_error_occurrences do |t|
+      t.bigint :error_log_id, null: false
+      t.datetime :occurred_at, null: false
+      t.integer :user_id
+      t.string :request_id
+      t.string :session_id
+      t.timestamps
+    end
+    add_index :rails_error_dashboard_error_occurrences, :error_log_id, name: "index_error_occurrences_on_error_log"
+    add_index :rails_error_dashboard_error_occurrences, [ :occurred_at, :error_log_id ], name: "index_error_occurrences_on_time_and_error"
+    add_index :rails_error_dashboard_error_occurrences, :user_id, name: "index_error_occurrences_on_user"
+    add_index :rails_error_dashboard_error_occurrences, :request_id, name: "index_error_occurrences_on_request"
+
+    # Create cascade_patterns table (from 20251225101920)
+    create_table :rails_error_dashboard_cascade_patterns do |t|
+      t.bigint :parent_error_id, null: false
+      t.bigint :child_error_id, null: false
+      t.integer :frequency, default: 1, null: false
+      t.float :avg_delay_seconds
+      t.float :cascade_probability
+      t.datetime :last_detected_at
+      t.timestamps
+    end
+    add_index :rails_error_dashboard_cascade_patterns, :parent_error_id, name: "index_cascade_patterns_on_parent"
+    add_index :rails_error_dashboard_cascade_patterns, :child_error_id, name: "index_cascade_patterns_on_child"
+    add_index :rails_error_dashboard_cascade_patterns, [ :parent_error_id, :child_error_id ], unique: true, name: "index_cascade_patterns_on_parent_and_child"
+    add_index :rails_error_dashboard_cascade_patterns, :cascade_probability, name: "index_cascade_patterns_on_probability"
+
+    # Create error_baselines table (from 20251225102500)
+    create_table :rails_error_dashboard_error_baselines do |t|
+      t.string :error_type, null: false
+      t.string :platform, null: false
+      t.string :baseline_type, null: false
+      t.datetime :period_start, null: false
+      t.datetime :period_end, null: false
+      t.integer :count, default: 0, null: false
+      t.float :mean
+      t.float :std_dev
+      t.float :percentile_95
+      t.float :percentile_99
+      t.integer :sample_size, default: 0, null: false
+      t.timestamps
+    end
+    add_index :rails_error_dashboard_error_baselines, [ :error_type, :platform ], name: "index_error_baselines_on_error_type_and_platform"
+    add_index :rails_error_dashboard_error_baselines, :period_end, name: "index_error_baselines_on_period_end"
+    add_index :rails_error_dashboard_error_baselines, [ :error_type, :platform, :baseline_type, :period_start ], name: "index_error_baselines_on_type_platform_baseline_period"
+
+    # Create error_comments table (from 20251226020100)
+    create_table :rails_error_dashboard_error_comments do |t|
+      t.bigint :error_log_id, null: false
+      t.string :author_name, null: false
+      t.text :body, null: false
+      t.timestamps
+    end
+    add_index :rails_error_dashboard_error_comments, :error_log_id
+    add_index :rails_error_dashboard_error_comments, [ :error_log_id, :created_at ], name: "index_error_comments_on_error_and_time"
+
+    # Create swallowed_exceptions table (from 20260306000003)
+    create_table :rails_error_dashboard_swallowed_exceptions do |t|
+      t.string   :exception_class,  null: false, limit: 250
+      t.string   :raise_location,   null: false, limit: 250
+      t.string   :rescue_location,  limit: 250
+      t.datetime :period_hour,      null: false
+      t.integer  :raise_count,      null: false, default: 0
+      t.integer  :rescue_count,     null: false, default: 0
+      t.datetime :last_seen_at
+      t.bigint   :application_id
+      t.timestamps
+    end
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :exception_class, :period_hour ],
+              name: "index_swallowed_exceptions_on_class_and_hour"
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              :period_hour,
+              name: "index_swallowed_exceptions_on_period_hour"
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :application_id, :period_hour ],
+              name: "index_swallowed_exceptions_on_app_and_hour"
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :exception_class, :raise_location, :rescue_location, :period_hour, :application_id ],
+              unique: true,
+              name: "index_swallowed_exceptions_upsert_key"
+
+    # PostgreSQL-specific indexes (BRIN + functional for time-series optimization)
+    if ActiveRecord::Base.connection.adapter_name.downcase == "postgresql"
+      execute <<-SQL
+        CREATE INDEX index_error_logs_on_occurred_at_brin
+        ON rails_error_dashboard_error_logs
+        USING brin (occurred_at)
+      SQL
+
+      execute <<-SQL
+        CREATE INDEX index_error_logs_on_occurred_at_day
+        ON rails_error_dashboard_error_logs
+        (DATE_TRUNC('day', occurred_at))
+      SQL
+
+      execute <<-SQL
+        CREATE INDEX index_error_logs_on_occurred_at_hour
+        ON rails_error_dashboard_error_logs
+        (DATE_TRUNC('hour', occurred_at))
+      SQL
+    end
+
+    # Add foreign keys
+    add_foreign_key :rails_error_dashboard_error_logs, :rails_error_dashboard_applications, column: :application_id
+    add_foreign_key :rails_error_dashboard_error_occurrences, :rails_error_dashboard_error_logs, column: :error_log_id
+    add_foreign_key :rails_error_dashboard_cascade_patterns, :rails_error_dashboard_error_logs, column: :parent_error_id
+    add_foreign_key :rails_error_dashboard_cascade_patterns, :rails_error_dashboard_error_logs, column: :child_error_id
+    add_foreign_key :rails_error_dashboard_error_comments, :rails_error_dashboard_error_logs, column: :error_log_id
+  end
+
+  def down
+    drop_table :rails_error_dashboard_swallowed_exceptions, if_exists: true
+    drop_table :rails_error_dashboard_error_comments, if_exists: true
+    drop_table :rails_error_dashboard_cascade_patterns, if_exists: true
+    drop_table :rails_error_dashboard_error_baselines, if_exists: true
+    drop_table :rails_error_dashboard_error_occurrences, if_exists: true
+    drop_table :rails_error_dashboard_error_logs, if_exists: true
+    drop_table :rails_error_dashboard_applications, if_exists: true
+  end
+end

--- a/db/migrate/20260625184348_create_rails_error_dashboard_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184348_create_rails_error_dashboard_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CreateRailsErrorDashboardErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already ran (checks for column added in later migration)
+    # If application_id column exists, the squashed migration created the table
+    return if table_exists?(:rails_error_dashboard_error_logs) &&
+              column_exists?(:rails_error_dashboard_error_logs, :application_id)
+
+    create_table :rails_error_dashboard_error_logs do |t|
+      # Error details
+      t.string :error_type, null: false
+      t.text :message, null: false
+      t.text :backtrace
+
+      # Context
+      t.integer :user_id
+      t.text :request_url
+      t.text :request_params
+      t.text :user_agent
+      t.string :ip_address
+      t.string :environment, null: false
+      t.string :platform
+
+      # Resolution tracking
+      t.boolean :resolved, default: false, null: false
+      t.text :resolution_comment
+      t.string :resolution_reference
+      t.string :resolved_by_name
+      t.datetime :resolved_at
+
+      # Timestamps
+      t.datetime :occurred_at, null: false
+      t.timestamps
+    end
+
+    # Indexes for performance
+    add_index :rails_error_dashboard_error_logs, :user_id
+    add_index :rails_error_dashboard_error_logs, :error_type
+    add_index :rails_error_dashboard_error_logs, :environment
+    add_index :rails_error_dashboard_error_logs, :resolved
+    add_index :rails_error_dashboard_error_logs, :occurred_at
+    add_index :rails_error_dashboard_error_logs, :platform
+  end
+end

--- a/db/migrate/20260625184349_add_better_tracking_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184349_add_better_tracking_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,16 @@
+class AddBetterTrackingToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already added these columns
+    return if column_exists?(:rails_error_dashboard_error_logs, :error_hash)
+
+    add_column :rails_error_dashboard_error_logs, :error_hash, :string
+    add_column :rails_error_dashboard_error_logs, :first_seen_at, :datetime
+    add_column :rails_error_dashboard_error_logs, :last_seen_at, :datetime
+    add_column :rails_error_dashboard_error_logs, :occurrence_count, :integer, default: 1, null: false
+
+    add_index :rails_error_dashboard_error_logs, :error_hash
+    add_index :rails_error_dashboard_error_logs, :first_seen_at
+    add_index :rails_error_dashboard_error_logs, :last_seen_at
+    add_index :rails_error_dashboard_error_logs, :occurrence_count
+  end
+end

--- a/db/migrate/20260625184350_add_controller_action_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184350_add_controller_action_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,13 @@
+class AddControllerActionToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already added these columns
+    return if column_exists?(:rails_error_dashboard_error_logs, :controller_name)
+
+    add_column :rails_error_dashboard_error_logs, :controller_name, :string
+    add_column :rails_error_dashboard_error_logs, :action_name, :string
+
+    # Add composite index for efficient querying by controller/action
+    add_index :rails_error_dashboard_error_logs, [ :controller_name, :action_name, :error_hash ],
+              name: 'index_error_logs_on_controller_action_hash'
+  end
+end

--- a/db/migrate/20260625184351_add_optimized_indexes_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184351_add_optimized_indexes_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class AddOptimizedIndexesToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already added these indexes
+    return if index_exists?(:rails_error_dashboard_error_logs, [ :resolved, :occurred_at ],
+                            name: 'index_error_logs_on_resolved_and_occurred_at')
+
+    # Composite indexes for common query patterns
+    # These improve performance when filtering and sorting together
+
+    # Dashboard stats: Count unresolved errors from recent time periods
+    # Query: WHERE resolved = false AND occurred_at >= ?
+    add_index :rails_error_dashboard_error_logs, [ :resolved, :occurred_at ],
+              name: 'index_error_logs_on_resolved_and_occurred_at'
+
+    # Error type filtering with time ordering
+    # Query: WHERE error_type = ? ORDER BY occurred_at DESC
+    add_index :rails_error_dashboard_error_logs, [ :error_type, :occurred_at ],
+              name: 'index_error_logs_on_error_type_and_occurred_at'
+
+    # Platform filtering with time ordering
+    # Query: WHERE platform = ? ORDER BY occurred_at DESC
+    add_index :rails_error_dashboard_error_logs, [ :platform, :occurred_at ],
+              name: 'index_error_logs_on_platform_and_occurred_at'
+
+    # Deduplication lookup: Find existing unresolved errors by hash within 24 hours
+    # Query: WHERE error_hash = ? AND resolved = false AND occurred_at >= ?
+    # This is the hot path for error logging - happens on EVERY error
+    add_index :rails_error_dashboard_error_logs, [ :error_hash, :resolved, :occurred_at ],
+              name: 'index_error_logs_on_hash_resolved_occurred'
+
+    # Partial index for unresolved errors (most queries filter by resolved=false)
+    # Only indexes unresolved errors, making it smaller and faster
+    # PostgreSQL-specific but gracefully ignored on other databases
+    if postgresql?
+      add_index :rails_error_dashboard_error_logs, :occurred_at,
+                where: "resolved = false",
+                name: 'index_error_logs_on_occurred_at_unresolved'
+
+      # Full-text search index for message field (PostgreSQL only)
+      # Dramatically improves search performance
+      execute <<-SQL
+        CREATE INDEX index_error_logs_on_message_gin
+        ON rails_error_dashboard_error_logs
+        USING gin(to_tsvector('english', message))
+      SQL
+    end
+  end
+
+  def down
+    # Remove composite indexes
+    remove_index :rails_error_dashboard_error_logs, name: 'index_error_logs_on_resolved_and_occurred_at'
+    remove_index :rails_error_dashboard_error_logs, name: 'index_error_logs_on_error_type_and_occurred_at'
+    remove_index :rails_error_dashboard_error_logs, name: 'index_error_logs_on_platform_and_occurred_at'
+    remove_index :rails_error_dashboard_error_logs, name: 'index_error_logs_on_hash_resolved_occurred'
+
+    # Remove partial/GIN indexes if PostgreSQL
+    if postgresql?
+      remove_index :rails_error_dashboard_error_logs, name: 'index_error_logs_on_occurred_at_unresolved'
+      execute "DROP INDEX IF EXISTS index_error_logs_on_message_gin"
+    end
+  end
+
+  private
+
+  def postgresql?
+    ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
+  end
+end

--- a/db/migrate/20260625184352_remove_environment_from_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184352_remove_environment_from_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,29 @@
+class RemoveEnvironmentFromErrorLogs < ActiveRecord::Migration[7.0]
+  def up
+    # Skip if squashed migration ran (column never existed) or already removed
+    return unless column_exists?(:rails_error_dashboard_error_logs, :environment)
+
+    # Remove composite index first
+    remove_index :rails_error_dashboard_error_logs,
+                 name: 'index_error_logs_on_environment_and_occurred_at',
+                 if_exists: true
+
+    # Remove single column index
+    remove_index :rails_error_dashboard_error_logs,
+                 column: :environment,
+                 if_exists: true
+
+    # Remove the column
+    remove_column :rails_error_dashboard_error_logs, :environment, :string
+  end
+
+  def down
+    # Add column back
+    add_column :rails_error_dashboard_error_logs, :environment, :string, null: false, default: 'production'
+
+    # Recreate indexes
+    add_index :rails_error_dashboard_error_logs, :environment
+    add_index :rails_error_dashboard_error_logs, [ :environment, :occurred_at ],
+              name: 'index_error_logs_on_environment_and_occurred_at'
+  end
+end

--- a/db/migrate/20260625184353_add_enhanced_metrics_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184353_add_enhanced_metrics_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,15 @@
+class AddEnhancedMetricsToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already added these columns
+    return if column_exists?(:rails_error_dashboard_error_logs, :app_version)
+
+    add_column :rails_error_dashboard_error_logs, :app_version, :string
+    add_column :rails_error_dashboard_error_logs, :git_sha, :string
+    add_column :rails_error_dashboard_error_logs, :priority_score, :integer
+
+    # Indexes for enhanced metrics
+    add_index :rails_error_dashboard_error_logs, :app_version
+    add_index :rails_error_dashboard_error_logs, :git_sha
+    add_index :rails_error_dashboard_error_logs, :priority_score
+  end
+end

--- a/db/migrate/20260625184354_add_similarity_tracking_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184354_add_similarity_tracking_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,12 @@
+class AddSimilarityTrackingToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already added these columns
+    return if column_exists?(:rails_error_dashboard_error_logs, :similarity_score)
+
+    add_column :rails_error_dashboard_error_logs, :similarity_score, :float
+    add_column :rails_error_dashboard_error_logs, :backtrace_signature, :string
+
+    add_index :rails_error_dashboard_error_logs, :similarity_score
+    add_index :rails_error_dashboard_error_logs, :backtrace_signature
+  end
+end

--- a/db/migrate/20260625184355_create_error_occurrences.rails_error_dashboard.rb
+++ b/db/migrate/20260625184355_create_error_occurrences.rails_error_dashboard.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateErrorOccurrences < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already created this table
+    return if table_exists?(:rails_error_dashboard_error_occurrences)
+
+    create_table :rails_error_dashboard_error_occurrences do |t|
+      t.references :error_log, null: false, foreign_key: { to_table: :rails_error_dashboard_error_logs }
+      t.datetime :occurred_at, null: false
+      t.integer :user_id
+      t.string :request_id
+      t.string :session_id
+
+      t.timestamps
+    end
+
+    # Index for finding co-occurring errors by time window
+    add_index :rails_error_dashboard_error_occurrences, [ :occurred_at, :error_log_id ],
+              name: 'index_error_occurrences_on_time_and_error'
+
+    # Index for finding all occurrences of a specific error
+    add_index :rails_error_dashboard_error_occurrences, :error_log_id,
+              name: 'index_error_occurrences_on_error_log'
+
+    # Index for finding errors by user
+    add_index :rails_error_dashboard_error_occurrences, :user_id,
+              name: 'index_error_occurrences_on_user'
+
+    # Index for finding errors by request
+    add_index :rails_error_dashboard_error_occurrences, :request_id,
+              name: 'index_error_occurrences_on_request'
+  end
+end

--- a/db/migrate/20260625184356_create_cascade_patterns.rails_error_dashboard.rb
+++ b/db/migrate/20260625184356_create_cascade_patterns.rails_error_dashboard.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class CreateCascadePatterns < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already created this table
+    return if table_exists?(:rails_error_dashboard_cascade_patterns)
+
+    create_table :rails_error_dashboard_cascade_patterns do |t|
+      t.references :parent_error, null: false, foreign_key: { to_table: :rails_error_dashboard_error_logs }
+      t.references :child_error, null: false, foreign_key: { to_table: :rails_error_dashboard_error_logs }
+      t.integer :frequency, default: 1, null: false
+      t.float :avg_delay_seconds
+      t.float :cascade_probability # 0.0-1.0, percentage of time parent leads to child
+      t.datetime :last_detected_at
+
+      t.timestamps
+    end
+
+    # Composite index for finding cascade patterns
+    add_index :rails_error_dashboard_cascade_patterns, [ :parent_error_id, :child_error_id ],
+              name: 'index_cascade_patterns_on_parent_and_child',
+              unique: true
+
+    # Index for finding children of a parent error
+    add_index :rails_error_dashboard_cascade_patterns, :parent_error_id,
+              name: 'index_cascade_patterns_on_parent'
+
+    # Index for finding parents of a child error
+    add_index :rails_error_dashboard_cascade_patterns, :child_error_id,
+              name: 'index_cascade_patterns_on_child'
+
+    # Index for finding by probability (for high-confidence cascades)
+    add_index :rails_error_dashboard_cascade_patterns, :cascade_probability,
+              name: 'index_cascade_patterns_on_probability'
+  end
+end

--- a/db/migrate/20260625184357_create_error_baselines.rails_error_dashboard.rb
+++ b/db/migrate/20260625184357_create_error_baselines.rails_error_dashboard.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class CreateErrorBaselines < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already created this table
+    return if table_exists?(:rails_error_dashboard_error_baselines)
+
+    create_table :rails_error_dashboard_error_baselines do |t|
+      t.string :error_type, null: false
+      t.string :platform, null: false
+      t.string :baseline_type, null: false # hourly, daily, weekly
+      t.datetime :period_start, null: false
+      t.datetime :period_end, null: false
+
+      # Statistical metrics
+      t.integer :count, null: false, default: 0
+      t.float :mean
+      t.float :std_dev
+      t.float :percentile_95
+      t.float :percentile_99
+      t.integer :sample_size, null: false, default: 0
+
+      t.timestamps
+    end
+
+    # Composite index for efficient baseline lookups
+    add_index :rails_error_dashboard_error_baselines,
+              [ :error_type, :platform, :baseline_type, :period_start ],
+              name: 'index_error_baselines_on_type_platform_baseline_period'
+
+    # Index for querying by error_type and platform
+    add_index :rails_error_dashboard_error_baselines,
+              [ :error_type, :platform ],
+              name: 'index_error_baselines_on_error_type_and_platform'
+
+    # Index for cleaning up old baselines
+    add_index :rails_error_dashboard_error_baselines,
+              :period_end,
+              name: 'index_error_baselines_on_period_end'
+  end
+end

--- a/db/migrate/20260625184358_add_workflow_fields_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184358_add_workflow_fields_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddWorkflowFieldsToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already added these columns
+    return if column_exists?(:rails_error_dashboard_error_logs, :status)
+
+    add_column :rails_error_dashboard_error_logs, :status, :string, default: 'new', null: false
+    add_column :rails_error_dashboard_error_logs, :assigned_to, :string
+    add_column :rails_error_dashboard_error_logs, :assigned_at, :datetime
+    add_column :rails_error_dashboard_error_logs, :snoozed_until, :datetime
+    add_column :rails_error_dashboard_error_logs, :priority_level, :integer, default: 0, null: false
+
+    add_index :rails_error_dashboard_error_logs, :status
+    add_index :rails_error_dashboard_error_logs, :assigned_to
+    add_index :rails_error_dashboard_error_logs, :snoozed_until
+    add_index :rails_error_dashboard_error_logs, :priority_level
+
+    # Update existing resolved errors to have status='resolved'
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE rails_error_dashboard_error_logs
+          SET status = 'resolved'
+          WHERE resolved = true
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20260625184359_create_error_comments.rails_error_dashboard.rb
+++ b/db/migrate/20260625184359_create_error_comments.rails_error_dashboard.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateErrorComments < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already created this table
+    return if table_exists?(:rails_error_dashboard_error_comments)
+
+    create_table :rails_error_dashboard_error_comments do |t|
+      t.references :error_log,
+                   null: false,
+                   foreign_key: { to_table: :rails_error_dashboard_error_logs }
+      t.string :author_name, null: false
+      t.text :body, null: false
+
+      t.timestamps
+    end
+
+    add_index :rails_error_dashboard_error_comments, [ :error_log_id, :created_at ],
+              name: 'index_error_comments_on_error_and_time'
+  end
+end

--- a/db/migrate/20260625184360_add_additional_performance_indexes.rails_error_dashboard.rb
+++ b/db/migrate/20260625184360_add_additional_performance_indexes.rails_error_dashboard.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class AddAdditionalPerformanceIndexes < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already added these indexes
+    return if index_exists?(:rails_error_dashboard_error_logs, [ :assigned_to, :status, :occurred_at ],
+                            name: 'index_error_logs_on_assignment_workflow')
+
+    # Composite index for workflow filtering (assigned errors with status)
+    # Common query: WHERE assigned_to = ? AND status = ? ORDER BY occurred_at DESC
+    # Used in: "Show me all errors assigned to John that are investigating"
+    add_index :rails_error_dashboard_error_logs, [ :assigned_to, :status, :occurred_at ],
+              name: 'index_error_logs_on_assignment_workflow',
+              if_not_exists: true
+
+    # Composite index for priority filtering with resolution status
+    # Common query: WHERE priority_level = ? AND resolved = ? ORDER BY occurred_at DESC
+    # Used in: "Show me all high priority unresolved errors"
+    add_index :rails_error_dashboard_error_logs, [ :priority_level, :resolved, :occurred_at ],
+              name: 'index_error_logs_on_priority_resolution',
+              if_not_exists: true
+
+    # Composite index for platform + status filtering (common in analytics)
+    # Common query: WHERE platform = ? AND status = ? ORDER BY occurred_at DESC
+    # Used in: "Show me all iOS errors that are new"
+    add_index :rails_error_dashboard_error_logs, [ :platform, :status, :occurred_at ],
+              name: 'index_error_logs_on_platform_status_time',
+              if_not_exists: true
+
+    # Composite index for version-based filtering
+    # Common query: WHERE app_version = ? AND resolved = ? ORDER BY occurred_at DESC
+    # Used in: "Show me all unresolved errors in version 2.1.0"
+    add_index :rails_error_dashboard_error_logs, [ :app_version, :resolved, :occurred_at ],
+              name: 'index_error_logs_on_version_resolution_time',
+              if_not_exists: true
+
+    # Composite index for snooze management
+    # Common query: WHERE snoozed_until IS NOT NULL AND snoozed_until < NOW()
+    # Used in: Finding errors that need to be unsnoozed
+    add_index :rails_error_dashboard_error_logs, [ :snoozed_until, :occurred_at ],
+              name: 'index_error_logs_on_snooze_time',
+              where: "snoozed_until IS NOT NULL",
+              if_not_exists: true
+
+    # Composite index for error hash lookups with time window
+    # Common query: WHERE error_hash = ? AND occurred_at >= ?
+    # Used in: Similar error detection within time windows
+    # Note: There's already an index on [error_hash, resolved, occurred_at]
+    # but this one is for time-based similarity without resolved filter
+
+    # Add GIN index for backtrace full-text search (PostgreSQL only)
+    # Improves search performance across both message and backtrace
+    if postgresql?
+      reversible do |dir|
+        dir.up do
+          execute <<-SQL
+            CREATE INDEX IF NOT EXISTS index_error_logs_on_searchable_text
+            ON rails_error_dashboard_error_logs
+            USING gin(to_tsvector('english',
+              COALESCE(message, '') || ' ' ||
+              COALESCE(backtrace, '') || ' ' ||
+              COALESCE(error_type, '')
+            ))
+          SQL
+        end
+
+        dir.down do
+          execute "DROP INDEX IF EXISTS index_error_logs_on_searchable_text"
+        end
+      end
+    end
+  end
+
+  private
+
+  def postgresql?
+    ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
+  end
+end

--- a/db/migrate/20260625184361_cleanup_orphaned_migrations.rails_error_dashboard.rb
+++ b/db/migrate/20260625184361_cleanup_orphaned_migrations.rails_error_dashboard.rb
@@ -1,0 +1,4 @@
+class CleanupOrphanedMigrations < ActiveRecord::Migration[7.0]
+  def change
+  end
+end

--- a/db/migrate/20260625184362_create_rails_error_dashboard_applications.rails_error_dashboard.rb
+++ b/db/migrate/20260625184362_create_rails_error_dashboard_applications.rails_error_dashboard.rb
@@ -1,0 +1,16 @@
+class CreateRailsErrorDashboardApplications < ActiveRecord::Migration[7.0]
+  def change
+    # Skip if squashed migration already ran (applications table already exists)
+    return if table_exists?(:rails_error_dashboard_applications)
+
+    create_table :rails_error_dashboard_applications do |t|
+      t.string :name, null: false, limit: 255
+      t.text :description
+
+      t.timestamps
+    end
+
+    # Unique constraint - app names must be unique
+    add_index :rails_error_dashboard_applications, :name, unique: true
+  end
+end

--- a/db/migrate/20260625184363_add_application_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184363_add_application_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,27 @@
+class AddApplicationToErrorLogs < ActiveRecord::Migration[7.0]
+  def up
+    # Skip if squashed migration already added this column
+    return if column_exists?(:rails_error_dashboard_error_logs, :application_id)
+
+    # Add nullable column first (for existing records)
+    add_column :rails_error_dashboard_error_logs, :application_id, :bigint
+
+    # Add indexes for performance
+    add_index :rails_error_dashboard_error_logs, :application_id
+
+    add_index :rails_error_dashboard_error_logs,
+              [ :application_id, :occurred_at ],
+              name: 'index_error_logs_on_app_occurred'
+
+    add_index :rails_error_dashboard_error_logs,
+              [ :application_id, :resolved ],
+              name: 'index_error_logs_on_app_resolved'
+  end
+
+  def down
+    remove_index :rails_error_dashboard_error_logs, name: 'index_error_logs_on_app_resolved'
+    remove_index :rails_error_dashboard_error_logs, name: 'index_error_logs_on_app_occurred'
+    remove_index :rails_error_dashboard_error_logs, column: :application_id
+    remove_column :rails_error_dashboard_error_logs, :application_id
+  end
+end

--- a/db/migrate/20260625184364_backfill_application_for_existing_errors.rails_error_dashboard.rb
+++ b/db/migrate/20260625184364_backfill_application_for_existing_errors.rails_error_dashboard.rb
@@ -1,0 +1,23 @@
+class BackfillApplicationForExistingErrors < ActiveRecord::Migration[7.0]
+  def up
+    return if RailsErrorDashboard::ErrorLog.count.zero?
+
+    # Create default application
+    default_name = ENV['APPLICATION_NAME'] ||
+                   (defined?(Rails) && Rails.application.class.module_parent_name) ||
+                   'Legacy Application'
+
+    app = RailsErrorDashboard::Application.find_or_create_by!(name: default_name) do |a|
+      a.description = 'Auto-created during migration for existing errors'
+    end
+
+    # Backfill in batches
+    RailsErrorDashboard::ErrorLog.where(application_id: nil).in_batches(of: 1000) do |batch|
+      batch.update_all(application_id: app.id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260625184365_finalize_application_foreign_key.rails_error_dashboard.rb
+++ b/db/migrate/20260625184365_finalize_application_foreign_key.rails_error_dashboard.rb
@@ -1,0 +1,22 @@
+class FinalizeApplicationForeignKey < ActiveRecord::Migration[7.0]
+  def up
+    # Skip if squashed migration already added the foreign key
+    return if foreign_key_exists?(:rails_error_dashboard_error_logs,
+                                   :rails_error_dashboard_applications,
+                                   column: :application_id)
+
+    # Make NOT NULL
+    change_column_null :rails_error_dashboard_error_logs, :application_id, false
+
+    # Add FK constraint
+    add_foreign_key :rails_error_dashboard_error_logs,
+                    :rails_error_dashboard_applications,
+                    column: :application_id,
+                    on_delete: :restrict
+  end
+
+  def down
+    remove_foreign_key :rails_error_dashboard_error_logs, column: :application_id
+    change_column_null :rails_error_dashboard_error_logs, :application_id, true
+  end
+end

--- a/db/migrate/20260625184366_add_exception_cause_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184366_add_exception_cause_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddExceptionCauseToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    unless column_exists?(:rails_error_dashboard_error_logs, :exception_cause)
+      add_column :rails_error_dashboard_error_logs, :exception_cause, :text
+    end
+  end
+end

--- a/db/migrate/20260625184367_add_enriched_context_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184367_add_enriched_context_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddEnrichedContextToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    unless column_exists?(:rails_error_dashboard_error_logs, :http_method)
+      add_column :rails_error_dashboard_error_logs, :http_method, :string, limit: 10
+      add_column :rails_error_dashboard_error_logs, :hostname, :string, limit: 255
+      add_column :rails_error_dashboard_error_logs, :content_type, :string, limit: 100
+      add_column :rails_error_dashboard_error_logs, :request_duration_ms, :integer
+    end
+  end
+end

--- a/db/migrate/20260625184368_add_time_series_indexes_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184368_add_time_series_indexes_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Tier 0 time-series optimization: BRIN and functional indexes
+#
+# BRIN (Block Range Index) on occurred_at:
+# - 99.9% smaller than B-tree (72KB vs 676MB on 100M rows)
+# - Nearly identical query performance for time-range scans
+# - Perfect for INSERT-heavy tables with naturally ordered timestamps
+#
+# Functional indexes for Groupdate:
+# - Pre-compute DATE_TRUNC expressions used by group_by_day/group_by_hour
+# - Up to 70x speedup on analytics dashboard queries
+#
+# All PostgreSQL-specific — gracefully skipped on SQLite/MySQL.
+class AddTimeSeriesIndexesToErrorLogs < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    return unless postgresql?
+
+    # BRIN index on occurred_at for time-range scans
+    # Replaces expensive B-tree sequential scans on large tables
+    unless index_exists?(:rails_error_dashboard_error_logs, :occurred_at, name: "index_error_logs_on_occurred_at_brin")
+      execute <<-SQL
+        CREATE INDEX CONCURRENTLY index_error_logs_on_occurred_at_brin
+        ON rails_error_dashboard_error_logs
+        USING brin (occurred_at)
+      SQL
+    end
+
+    # Functional index for daily grouping (used by group_by_day)
+    unless index_exists_by_name?("index_error_logs_on_occurred_at_day")
+      execute <<-SQL
+        CREATE INDEX CONCURRENTLY index_error_logs_on_occurred_at_day
+        ON rails_error_dashboard_error_logs
+        (DATE_TRUNC('day', occurred_at))
+      SQL
+    end
+
+    # Functional index for hourly grouping (used by group_by_hour)
+    unless index_exists_by_name?("index_error_logs_on_occurred_at_hour")
+      execute <<-SQL
+        CREATE INDEX CONCURRENTLY index_error_logs_on_occurred_at_hour
+        ON rails_error_dashboard_error_logs
+        (DATE_TRUNC('hour', occurred_at))
+      SQL
+    end
+  end
+
+  def down
+    return unless postgresql?
+
+    execute "DROP INDEX IF EXISTS index_error_logs_on_occurred_at_brin"
+    execute "DROP INDEX IF EXISTS index_error_logs_on_occurred_at_day"
+    execute "DROP INDEX IF EXISTS index_error_logs_on_occurred_at_hour"
+  end
+
+  private
+
+  def postgresql?
+    ActiveRecord::Base.connection.adapter_name.downcase == "postgresql"
+  end
+
+  def index_exists_by_name?(name)
+    ActiveRecord::Base.connection.execute(
+      "SELECT 1 FROM pg_indexes WHERE indexname = '#{name}'"
+    ).any?
+  end
+end

--- a/db/migrate/20260625184369_add_environment_info_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184369_add_environment_info_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddEnvironmentInfoToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    unless column_exists?(:rails_error_dashboard_error_logs, :environment_info)
+      add_column :rails_error_dashboard_error_logs, :environment_info, :text
+    end
+  end
+end

--- a/db/migrate/20260625184370_add_reopened_at_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184370_add_reopened_at_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddReopenedAtToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    unless column_exists?(:rails_error_dashboard_error_logs, :reopened_at)
+      add_column :rails_error_dashboard_error_logs, :reopened_at, :datetime
+    end
+  end
+end

--- a/db/migrate/20260625184371_add_breadcrumbs_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184371_add_breadcrumbs_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddBreadcrumbsToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    unless column_exists?(:rails_error_dashboard_error_logs, :breadcrumbs)
+      add_column :rails_error_dashboard_error_logs, :breadcrumbs, :text
+    end
+  end
+end

--- a/db/migrate/20260625184372_add_system_health_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184372_add_system_health_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddSystemHealthToErrorLogs < ActiveRecord::Migration[7.0]
+  def up
+    return if column_exists?(:rails_error_dashboard_error_logs, :system_health)
+    add_column :rails_error_dashboard_error_logs, :system_health, :text
+  end
+
+  def down
+    remove_column :rails_error_dashboard_error_logs, :system_health if column_exists?(:rails_error_dashboard_error_logs, :system_health)
+  end
+end

--- a/db/migrate/20260625184373_add_local_variables_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184373_add_local_variables_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddLocalVariablesToErrorLogs < ActiveRecord::Migration[7.0]
+  def up
+    return if column_exists?(:rails_error_dashboard_error_logs, :local_variables)
+
+    add_column :rails_error_dashboard_error_logs, :local_variables, :text
+  end
+
+  def down
+    remove_column :rails_error_dashboard_error_logs, :local_variables if column_exists?(:rails_error_dashboard_error_logs, :local_variables)
+  end
+end

--- a/db/migrate/20260625184374_add_instance_variables_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184374_add_instance_variables_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddInstanceVariablesToErrorLogs < ActiveRecord::Migration[7.0]
+  def up
+    return if column_exists?(:rails_error_dashboard_error_logs, :instance_variables)
+
+    add_column :rails_error_dashboard_error_logs, :instance_variables, :text
+  end
+
+  def down
+    remove_column :rails_error_dashboard_error_logs, :instance_variables if column_exists?(:rails_error_dashboard_error_logs, :instance_variables)
+  end
+end

--- a/db/migrate/20260625184375_create_rails_error_dashboard_swallowed_exceptions.rails_error_dashboard.rb
+++ b/db/migrate/20260625184375_create_rails_error_dashboard_swallowed_exceptions.rails_error_dashboard.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateRailsErrorDashboardSwallowedExceptions < ActiveRecord::Migration[7.0]
+  def change
+    # Guard against the squashed schema migration having already created this
+    # table — without it, every later migration is silently cancelled.
+    return if table_exists?(:rails_error_dashboard_swallowed_exceptions)
+
+    create_table :rails_error_dashboard_swallowed_exceptions do |t|
+      t.string   :exception_class,  null: false, limit: 250
+      t.string   :raise_location,   null: false, limit: 250
+      t.string   :rescue_location,  limit: 250
+      t.datetime :period_hour,      null: false
+      t.integer  :raise_count,      null: false, default: 0
+      t.integer  :rescue_count,     null: false, default: 0
+      t.datetime :last_seen_at
+      t.bigint   :application_id
+      t.timestamps
+    end
+
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :exception_class, :period_hour ],
+              name: "index_swallowed_exceptions_on_class_and_hour"
+
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              :period_hour,
+              name: "index_swallowed_exceptions_on_period_hour"
+
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :application_id, :period_hour ],
+              name: "index_swallowed_exceptions_on_app_and_hour"
+
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :exception_class, :raise_location, :rescue_location, :period_hour, :application_id ],
+              unique: true,
+              name: "index_swallowed_exceptions_upsert_key"
+  end
+end

--- a/db/migrate/20260625184376_create_rails_error_dashboard_diagnostic_dumps.rails_error_dashboard.rb
+++ b/db/migrate/20260625184376_create_rails_error_dashboard_diagnostic_dumps.rails_error_dashboard.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateRailsErrorDashboardDiagnosticDumps < ActiveRecord::Migration[7.0]
+  def change
+    # Guard against the squashed schema migration having already created this
+    # table — without it, every later migration is silently cancelled.
+    return if table_exists?(:rails_error_dashboard_diagnostic_dumps)
+
+    create_table :rails_error_dashboard_diagnostic_dumps do |t|
+      t.references :application, null: false,
+        foreign_key: { to_table: :rails_error_dashboard_applications }
+      t.text :dump_data, null: false
+      t.string :note
+      t.datetime :captured_at, null: false
+      t.timestamps
+    end
+
+    add_index :rails_error_dashboard_diagnostic_dumps, :captured_at,
+              name: "index_diagnostic_dumps_on_captured_at"
+  end
+end

--- a/db/migrate/20260625184377_add_muted_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184377_add_muted_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddMutedToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    return if column_exists?(:rails_error_dashboard_error_logs, :muted)
+
+    add_column :rails_error_dashboard_error_logs, :muted, :boolean, default: false, null: false
+    add_column :rails_error_dashboard_error_logs, :muted_at, :datetime
+    add_column :rails_error_dashboard_error_logs, :muted_by, :string
+    add_column :rails_error_dashboard_error_logs, :muted_reason, :string
+
+    add_index :rails_error_dashboard_error_logs, :muted
+  end
+end

--- a/db/migrate/20260625184378_fix_swallowed_exceptions_index_for_mysql.rails_error_dashboard.rb
+++ b/db/migrate/20260625184378_fix_swallowed_exceptions_index_for_mysql.rails_error_dashboard.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Fix MySQL "Specified key was too long" error on the swallowed_exceptions
+# composite unique index. The original columns (varchar 255 + 500 + 500)
+# total 5042 bytes under utf8mb4, exceeding MySQL's 3072-byte InnoDB limit.
+#
+# Reduces all three string columns to limit: 250, bringing the total to
+# 3022 bytes (250 * 4 * 3 + 6 length prefixes + 16 datetime/bigint).
+#
+# See: https://github.com/AnjanJ/rails_error_dashboard/issues/96
+class FixSwallowedExceptionsIndexForMysql < ActiveRecord::Migration[7.0]
+  def up
+    return unless table_exists?(:rails_error_dashboard_swallowed_exceptions)
+
+    # Remove the oversized index if it exists (it may not exist on MySQL
+    # since the original migration would have failed at this point)
+    if index_exists?(:rails_error_dashboard_swallowed_exceptions, name: "index_swallowed_exceptions_upsert_key")
+      remove_index :rails_error_dashboard_swallowed_exceptions, name: "index_swallowed_exceptions_upsert_key"
+    end
+
+    # Shrink columns to fit within MySQL's 3072-byte index key limit
+    change_column :rails_error_dashboard_swallowed_exceptions, :exception_class, :string, null: false, limit: 250
+    change_column :rails_error_dashboard_swallowed_exceptions, :raise_location, :string, null: false, limit: 250
+    change_column :rails_error_dashboard_swallowed_exceptions, :rescue_location, :string, limit: 250
+
+    # Re-add the index with the smaller columns
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :exception_class, :raise_location, :rescue_location, :period_hour, :application_id ],
+              unique: true,
+              name: "index_swallowed_exceptions_upsert_key"
+  end
+
+  def down
+    return unless table_exists?(:rails_error_dashboard_swallowed_exceptions)
+
+    if index_exists?(:rails_error_dashboard_swallowed_exceptions, name: "index_swallowed_exceptions_upsert_key")
+      remove_index :rails_error_dashboard_swallowed_exceptions, name: "index_swallowed_exceptions_upsert_key"
+    end
+
+    change_column :rails_error_dashboard_swallowed_exceptions, :exception_class, :string, null: false
+    change_column :rails_error_dashboard_swallowed_exceptions, :raise_location, :string, null: false, limit: 500
+    change_column :rails_error_dashboard_swallowed_exceptions, :rescue_location, :string, limit: 500
+
+    add_index :rails_error_dashboard_swallowed_exceptions,
+              [ :exception_class, :raise_location, :rescue_location, :period_hour, :application_id ],
+              unique: true,
+              name: "index_swallowed_exceptions_upsert_key"
+  end
+end

--- a/db/migrate/20260625184379_add_issue_tracking_to_error_logs.rails_error_dashboard.rb
+++ b/db/migrate/20260625184379_add_issue_tracking_to_error_logs.rails_error_dashboard.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Add columns for linking errors to external issue trackers (GitHub, GitLab, Codeberg/Gitea/Forgejo).
+# These columns store the relationship between an error and its tracked issue.
+#
+# See: https://github.com/AnjanJ/rails_error_dashboard
+class AddIssueTrackingToErrorLogs < ActiveRecord::Migration[7.0]
+  def change
+    return unless table_exists?(:rails_error_dashboard_error_logs)
+
+    add_column :rails_error_dashboard_error_logs, :external_issue_url, :string unless column_exists?(:rails_error_dashboard_error_logs, :external_issue_url)
+    add_column :rails_error_dashboard_error_logs, :external_issue_number, :integer unless column_exists?(:rails_error_dashboard_error_logs, :external_issue_number)
+    add_column :rails_error_dashboard_error_logs, :external_issue_provider, :string, limit: 20 unless column_exists?(:rails_error_dashboard_error_logs, :external_issue_provider)
+  end
+end

--- a/db/migrate/20260625184380_backfill_resolved_status.rails_error_dashboard.rb
+++ b/db/migrate/20260625184380_backfill_resolved_status.rails_error_dashboard.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Backfill `status` column for errors that were bulk-resolved before v0.6.3.
+#
+# Versions 0.6.0 through 0.6.2 had a bug in BatchResolveErrors that set
+# `resolved: true` and `resolved_at` but skipped the `status` column. The
+# errors-index "Resolved" filter pill queries `where(status: 'resolved')`,
+# so bulk-resolved errors silently disappeared from that view even though
+# they were marked resolved.
+#
+# This migration is idempotent: it only updates rows that are out-of-sync
+# (resolved but not status='resolved'). Running it twice is a no-op.
+#
+# See: https://github.com/AnjanJ/rails_error_dashboard
+class BackfillResolvedStatus < ActiveRecord::Migration[7.0]
+  def up
+    return unless table_exists?(:rails_error_dashboard_error_logs)
+    return unless column_exists?(:rails_error_dashboard_error_logs, :status)
+    return unless column_exists?(:rails_error_dashboard_error_logs, :resolved)
+
+    # Use ActiveRecord update_all so the count is portable across adapters
+    # (PostgreSQL, MySQL, SQLite all return the affected row count).
+    table = ActiveRecord::Base.connection.quote_table_name("rails_error_dashboard_error_logs")
+    klass = Class.new(ActiveRecord::Base) { self.table_name = "rails_error_dashboard_error_logs" }
+    updated = klass.where(resolved: true).where("status IS NULL OR status != ?", "resolved")
+                   .update_all(status: "resolved")
+
+    say "Backfilled status='resolved' on #{updated} error log(s) that were bulk-resolved on v0.6.0–v0.6.2."
+  end
+
+  def down
+    # No-op: we cannot reliably distinguish errors that were bulk-resolved
+    # before the fix from errors that are legitimately resolved now. Leaving
+    # status='resolved' is the safe choice on rollback.
+  end
+end

--- a/db/migrate/20260625184381_create_storm_events.rails_error_dashboard.rb
+++ b/db/migrate/20260625184381_create_storm_events.rails_error_dashboard.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Storm protection honesty layer: one row per storm episode, powering the
+# dashboard banner ("storm detected, counts recorded, detail sampled") and
+# the storm history page. Small table — a few rows per incident.
+class CreateStormEvents < ActiveRecord::Migration[7.0]
+  def change
+    return if table_exists?(:rails_error_dashboard_storm_events)
+
+    create_table :rails_error_dashboard_storm_events do |t|
+      t.datetime :started_at, null: false
+      t.datetime :ended_at                    # NULL while the storm is active
+      t.integer :peak_rate_per_minute, default: 0
+      t.boolean :reached_open, default: false # true if count-only mode engaged
+      t.bigint :events_total, default: 0      # count-only total = counted_only + overflow (excludes :lite/:full rows)
+      t.bigint :events_counted_only, default: 0 # counted in memory, no rows
+      t.bigint :events_overflow, default: 0   # beyond the bounded map — exact total, anonymous identity
+      t.integer :fingerprints_affected, default: 0
+      t.text :top_fingerprints                # JSON: top 5 by count [{class, message, count}]
+      t.timestamps
+    end
+
+    add_index :rails_error_dashboard_storm_events, :ended_at,
+              name: "index_red_storm_events_on_ended_at"
+    add_index :rails_error_dashboard_storm_events, :started_at,
+              name: "index_red_storm_events_on_started_at"
+  end
+end


### PR DESCRIPTION
# Integrate `rails_error_dashboard` for self-hosted exception tracking

Adds the [`rails_error_dashboard`](https://github.com/AnjanJ/rails_error_dashboard) engine as a self-hosted alternative to Sentry, which cannot be used for the public app. The dashboard is mounted at `/admin/red` alongside Blazer and is gated behind the same admin-user check.

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Sentry is unavailable for the public-facing app, so we needed a way to capture and review exceptions in production. Rather than building something custom, this integrates the `rails_error_dashboard` public Rails engine (v0.8.2), which provides middleware-based capture, a dashboard UI, deduplication, workflow status, and optional notifications — all stored in our own database.

**Key decisions:**

- **Auth**: The engine's default HTTP Basic Auth is bypassed. Instead, `config.authenticate_with` resolves the current user from the session (the same way `ApplicationController#current_user` does) and requires `user.admin?` — identical to the Blazer gate. The Basic Auth credentials are still set to non-default values so the gem's production safety check passes, but they can never be accidentally relied on.
- **Mount path**: Mounted at `admin/red` (next to `admin/blazer`) rather than the installer default of `/red`.
- **Async logging**: Enabled via Rails' built-in `:async` adapter — no extra worker infrastructure needed.
- **Retention**: 90-day automatic cleanup policy.
- **Notifications/advanced features**: All disabled by default; commented-out config blocks make them easy to enable later.
- **Database**: Errors are stored in the main app DB (35 engine migrations). The gem also supports `use_separate_database` if we want to isolate error data later.

Note: this gem is labeled **BETA** ("API may change before v1.0.0").

# Testing

1. Run `bundle install` and `bin/rails db:migrate` to apply the 35 engine migrations.
2. Start the server and log in as an admin user.
3. Visit `/admin/red` — the dashboard should load.
4. Smoke-test capture: `bin/rails runner 'Rails.error.report(RuntimeError.new("RED test"), handled: true)'` and refresh the dashboard to confirm the error appears.
5. Verify a non-admin user is denied access to `/admin/red`.

# Documentation

No external documentation required. The initializer at `config/initializers/rails_error_dashboard.rb` is extensively commented and serves as the configuration reference. Optional environment variables are documented in `.env.example`.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/bz7GJbf7pDdm/implementations/jqfMFwCkFQG6) | [App Preview](https://www.superconductor.com/tickets/bz7GJbf7pDdm/implementations/jqfMFwCkFQG6/preview) | [Guided Review](https://www.superconductor.com/tickets/bz7GJbf7pDdm/implementations/jqfMFwCkFQG6?tab=guided_review)

<!-- created-by-superconductor -->