### PR TITLE
Refresh Tokens on Login -> Better Sessions Experience 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include TokenRefreshable
+
   before_action :authenticated!, unless: -> { excluded_controller_action? }
 
   rescue_from LmsFacade::LmsAPIError, with: :handle_lms_api_error
@@ -54,7 +56,11 @@ class ApplicationController < ActionController::Base
       elsif current_user.lms_credentials.empty?
         return handle_authentication_failure('User has no credentials.')
       elsif current_user.lms_credentials.first.expire_time < Time.zone.now
-        return handle_authentication_failure('You have been logged out.')
+        # The Canvas access token has expired. Rather than logging the user out
+        # immediately, try to use the stored (long-lived) refresh token to obtain
+        # a fresh access token so the session can continue. We only log the user
+        # out when there is no refresh token or the refresh actually fails.
+        return handle_authentication_failure('You have been logged out.') unless refresh_user_token(current_user)
       end
     end
     true

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,6 +1,4 @@
 class SessionController < ApplicationController
-  include TokenRefreshable
-
   ## Login work flow explained here
   # Currently the login only supports third-party authentication with Canvas.
   # But the structure to support multiple login methods is largely in place.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,13 @@
+# Be sure to restart your server when you modify this file.
+
+# By default Rails uses a "session" cookie that is cleared as soon as the
+# browser is closed, which causes users to be logged out far too often.
+#
+# Giving the cookie an explicit `expire_after` lets the browser persist the
+# session across restarts so people stay logged in for the lifetime of the
+# cookie (as long as their Canvas refresh token is still valid). Combined with
+# refreshing the Canvas access token on expiry (see ApplicationController),
+# this keeps sessions alive much longer.
+Rails.application.config.session_store :cookie_store,
+                                       key: '_flextensions_session',
+                                       expire_after: 3.days

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -78,9 +78,20 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     context 'when user token has expired' do
-      it 'resets session and redirects with alert' do
+      before do
         user.lms_credentials.first.update!(expire_time: 1.hour.ago)
         session[:user_id] = user.canvas_uid
+      end
+
+      it 'refreshes the token and continues to the requested action when refresh succeeds' do
+        allow_any_instance_of(described_class).to receive(:refresh_user_token).and_return('new_token')
+
+        get :index
+        expect(response.body).to eq('OK')
+      end
+
+      it 'resets session and redirects with alert when refresh fails' do
+        allow_any_instance_of(described_class).to receive(:refresh_user_token).and_return(nil)
 
         get :index
         expect(response).to redirect_to(root_path)


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Users were being logged out roughly every hour because `ApplicationController#authenticated!` immediately ended sessions when a Canvas access token expired — even though the app already stores a long-lived refresh token and has working refresh machinery (`TokenRefreshable#refresh_user_token`). A second contributor was the lack of a persistent session cookie, meaning sessions also died on browser close.

**Root cause fix — `app/controllers/application_controller.rb`:**
Rather than logging the user out the moment the Canvas access token expires, we now attempt to refresh it using the stored refresh token. The user is only logged out if there is no refresh token or the refresh call actually fails. This makes the existing `TokenRefreshable` concern do its intended job at the authentication gate, not just during API calls.

**Persistent session cookie — `config/initializers/session_store.rb` (new):**
Configures the session cookie with an explicit `expire_after: 3.days` so it survives browser restarts. Without this, the longer-lived refresh token wouldn't help — the session cookie would still be cleared on browser close.

**Note on approach:** We deliberately reused the existing refresh-token flow rather than introducing a separate `remember_token` column or cookie. The Canvas refresh token already provides the "longer sessions" behavior the ticket wants, with no new schema and no new secret to manage. Sessions still end cleanly when Canvas revokes the refresh token. A dedicated server-side session store (e.g. `activerecord-session_store`) would add on-demand revocation capability but is out of scope here — the Canvas-side revocation path already covers the most important cases.

# Testing

- Added two regression tests to `spec/controllers/application_controller_spec.rb` covering the expired-token path:
  - Refresh succeeds → request continues normally.
  - Refresh fails → session is reset and user is redirected with an alert.
- Full suite: **432 examples, 0 failures**.
- RuboCop: clean on all changed files.

# Documentation

No external documentation required. The new session store initializer includes inline comments explaining the rationale.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/jjMLDTNrwJNg/implementations/wPtGChkWcjgB) | [App Preview](https://www.superconductor.com/tickets/jjMLDTNrwJNg/implementations/wPtGChkWcjgB/preview) | [Guided Review](https://www.superconductor.com/tickets/jjMLDTNrwJNg/implementations/wPtGChkWcjgB?tab=guided_review)

<!-- created-by-superconductor -->