### PR TITLE
An instructor reports that a Canvas assignment **when auto-approved** does not get an override posted to canvas. However manual request approvals d...

### DIFF
--- a/app/facades/canvas_facade.rb
+++ b/app/facades/canvas_facade.rb
@@ -352,16 +352,28 @@ class CanvasFacade < LmsFacade
     )
 
     decoded_response = parse_create_response(create_response)
-    if create_response.status != 400 || override_has_errors?(decoded_response)
-      return Lmss::Canvas::Override.new(decoded_response)
+
+    # Canvas returns a 2xx with the created override on success.
+    return Lmss::Canvas::Override.new(decoded_response) if (200..299).cover?(create_response.status)
+
+    # Canvas returns a 400 with a "taken" error when the student already belongs
+    # to an existing override. That is recoverable: fetch the existing override
+    # and update it (or split the student out of a shared override).
+    if create_response.status == 400 && !override_has_errors?(decoded_response)
+      curr_override = fetch_existing_override(course_id, student_id, assignment_id)
+      handle_response = handle_override_logic(
+        course_id, curr_override, student_id, assignment_id, override_title,
+        new_due_date, new_close_date
+      )
+      return Lmss::Canvas::Override.new(parse_create_response(handle_response))
     end
 
-    curr_override = fetch_existing_override(course_id, student_id, assignment_id)
-    handle_response = handle_override_logic(
-      course_id, curr_override, student_id, assignment_id, override_title,
-      new_due_date, new_close_date
-    )
-    Lmss::Canvas::Override.new(parse_create_response(handle_response))
+    # Any other response (e.g. 401/403 auth failures, 422 validation errors, 5xx,
+    # or a 400 carrying real errors) means Canvas did NOT create the override.
+    # Raise so the caller (Request#approve) does not mark the request approved
+    # without an override actually existing in Canvas.
+    raise CanvasAPIError,
+          "Canvas rejected the assignment override (HTTP #{create_response.status}): #{create_response.body}"
   end
 
   private

--- a/spec/facades/canvas_facade_spec.rb
+++ b/spec/facades/canvas_facade_spec.rb
@@ -424,6 +424,20 @@ describe CanvasFacade do
       end.to raise_error(FailedPipelineError)
     end
 
+    it 'raises when Canvas rejects the override with an auth error so the request is not silently approved' do
+      unauthorized_response = instance_double(Faraday::Response, status: 401, body: '{"errors":[{"message":"Invalid access token."}]}')
+      allow(facade).to receive(:create_assignment_override).and_return(unauthorized_response)
+
+      expect do
+        facade.provision_extension(
+          course_id,
+          student_id,
+          assignment_id,
+          mock_date
+        )
+      end.to raise_error(CanvasFacade::CanvasAPIError, /HTTP 401/)
+    end
+
     it 'throws an error if the existing override cannot be found' do
       allow(facade).to receive_messages(create_assignment_override: create_taken_response, get_existing_student_override: nil)
       expect do


### PR DESCRIPTION
# General Info

- Pivotal Tracker Story: (see ticket)
- [ ] Breaking?

# Changes

Fixes a bug where Canvas assignment overrides were silently not created during auto-approval, leaving the request falsely marked as "approved" in the database with no corresponding override in Canvas.

**Root cause:** `CanvasFacade#provision_extension` had inverted logic for handling non-success responses. Any status code that wasn't `400` (e.g. `401`, `403`, `422`, `5xx`) would fall through and wrap the error body in an `Override` object, returning it as if the override was successfully created. Back in `Request#approve`, this fake success caused the request to be marked `approved` with a `nil external_extension_id` — no override ever existed in Canvas.

Manual approvals appeared to work because they happened to succeed with `201`; the silent failure only surfaced on assignments where Canvas rejected the override creation with a non-400 status.

**Fix:** Rewrote the response-handling logic in `provision_extension` to be explicit about the three real cases:

- **2xx** → success, return the created override ✅
- **400 with only a `"taken"` error** → recoverable; fetch and update the existing override (unchanged behavior) ✅
- **Anything else** → raise `CanvasAPIError` with the HTTP status and Canvas response body

Now when Canvas rejects an override, `Request#approve`'s existing `rescue` catches the error, returns `false`, and leaves the request in a **pending** state rather than a phantom approved state. The specific Canvas error is also surfaced in logs for debugging.

# Testing

- Added a regression spec covering the `401` case, asserting that `provision_extension` raises `CanvasAPIError` (matching `HTTP 401`) instead of silently returning a fake override.
- All existing facade and request specs continue to pass.

# Documentation

No documentation changes required.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/tMFHbHzWWQtj/implementations/bLjjcdDP6JtD) | [App Preview](https://www.superconductor.com/tickets/tMFHbHzWWQtj/implementations/bLjjcdDP6JtD/preview) | [Guided Review](https://www.superconductor.com/tickets/tMFHbHzWWQtj/implementations/bLjjcdDP6JtD?tab=guided_review)

<!-- created-by-superconductor -->