### PR TITLE
Add course_id as a foreign key to the assignments table

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -103,7 +103,7 @@ class CoursesController < ApplicationController
     return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
     return redirect_to courses_path, alert: 'Extensions are enabled for this course.' if @course.course_settings&.enable_extensions
 
-    assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: @course.id).select(:id))
+    assignments = Assignment.where(course_id: @course.id)
     Extension.where(assignment_id: assignments.select(:id)).destroy_all
     assignments.destroy_all
     CourseToLms.where(course_id: @course.id).destroy_all

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -10,16 +10,28 @@
 #  name                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  course_id              :bigint           not null
 #  course_to_lms_id       :bigint           not null
 #  external_assignment_id :string
 #
+# Indexes
+#
+#  index_assignments_on_course_id  (course_id)
+#
 # Foreign Keys
 #
+#  fk_rails_...  (course_id => courses.id)
 #  fk_rails_...  (course_to_lms_id => course_to_lmss.id)
 #
 class Assignment < ApplicationRecord
   belongs_to :course_to_lms
+  belongs_to :course
   has_many :requests, dependent: :destroy
+
+  # course_id is a denormalized copy of course_to_lms.course_id that lets us look
+  # up a course's assignments without joining through course_to_lmss. Populate it
+  # automatically so every creation path (sync job, API, seeds) stays in sync.
+  before_validation :assign_course_from_lms
 
   validates :name, presence: true
   validates :external_assignment_id, presence: true
@@ -53,5 +65,12 @@ class Assignment < ApplicationRecord
     when GRADESCOPE_LMS_ID
       "#{base_lms_url}/courses/#{external_course_id}/assignments/#{external_assignment_id}"
     end
+  end
+
+  private
+
+  # Mirror the course from the LMS link so course_id is always populated.
+  def assign_course_from_lms
+    self.course ||= course_to_lms&.course
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -109,10 +109,6 @@ class Course < ApplicationRecord
     course_to_lms(1).present?
   end
 
-  def assignments
-    Assignment.where(course_to_lms: course_to_lmss).order(:name)
-  end
-
   def enabled_assignments
     assignments.where(enabled: true)
   end
@@ -156,7 +152,7 @@ class Course < ApplicationRecord
 
   # TODO: Add specs for these 4 simple methods
   def assignments
-    Assignment.joins(:course_to_lms).where(course_to_lms: { course_id: id })
+    Assignment.where(course_id: id)
   end
 
   def students

--- a/db/migrate/20260702000001_add_course_id_to_assignments.rb
+++ b/db/migrate/20260702000001_add_course_id_to_assignments.rb
@@ -1,0 +1,26 @@
+class AddCourseIdToAssignments < ActiveRecord::Migration[7.2]
+  # The assignments table is small (bounded by a course's assignment count), so
+  # the brief locks from adding the reference, FK, and NOT NULL are acceptable.
+  def up
+    safety_assured do
+      # Denormalized FK so assignments can be looked up by course without joining
+      # through course_to_lmss. Added nullable first so we can backfill existing rows.
+      add_reference :assignments, :course, foreign_key: true, null: true
+
+      # Backfill course_id from each assignment's existing course_to_lms link.
+      execute <<~SQL.squish
+        UPDATE assignments
+        SET course_id = course_to_lmss.course_id
+        FROM course_to_lmss
+        WHERE assignments.course_to_lms_id = course_to_lmss.id
+      SQL
+
+      # Every assignment belongs to a course, mirroring course_to_lms_id.
+      change_column_null :assignments, :course_id, false
+    end
+  end
+
+  def down
+    remove_reference :assignments, :course, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_22_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_02_000001) do
   create_schema "hypershield"
 
   # These are extensions that must be enabled in order to support this database
@@ -30,6 +30,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_22_000001) do
     t.datetime "due_date"
     t.datetime "late_due_date"
     t.boolean "enabled", default: false
+    t.bigint "course_id", null: false
+    t.index ["course_id"], name: "index_assignments_on_course_id"
   end
 
   create_table "blazer_audits", force: :cascade do |t|
@@ -232,6 +234,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_22_000001) do
   end
 
   add_foreign_key "assignments", "course_to_lmss"
+  add_foreign_key "assignments", "courses"
   add_foreign_key "course_settings", "courses"
   add_foreign_key "course_to_lmss", "courses"
   add_foreign_key "course_to_lmss", "lmss"

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -9,11 +9,17 @@
 #  name                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  course_id              :bigint           not null
 #  course_to_lms_id       :bigint           not null
 #  external_assignment_id :string
 #
+# Indexes
+#
+#  index_assignments_on_course_id  (course_id)
+#
 # Foreign Keys
 #
+#  fk_rails_...  (course_id => courses.id)
 #  fk_rails_...  (course_to_lms_id => course_to_lmss.id)
 #
 require 'rails_helper'


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Adds `course_id` as a denormalized foreign key on the `assignments` table so that assignments can be looked up by course without joining through `course_to_lmss`.

Previously, fetching a course's assignments required a join or subquery through the `course_to_lmss` table (`assignments.course_to_lms_id → course_to_lmss.course_id → courses`). This change adds a direct `course_id` column to `assignments`, eliminating that join from the hot paths used by the instructor dashboard, request forms, and course deletion.

Key changes:
- **Migration** — adds `course_id` (nullable first, backfills from `course_to_lmss` via a single `UPDATE ... FROM`, then sets `NOT NULL`). Wrapped in `safety_assured` per the repo's `strong_migrations` convention.
- **`Assignment` model** — adds `belongs_to :course` and a `before_validation :assign_course_from_lms` callback (`self.course ||= course_to_lms&.course`) to keep `course_id` populated automatically across all creation paths (sync jobs, API, seeds, factories) without touching each one individually.
- **`Course` model** — `Course#assignments` now uses `Assignment.where(course_id: id)` instead of a join through `course_to_lmss`. Also removes a duplicate (shadowed) `assignments` method definition.
- **`CoursesController`** — the `delete` action's assignment lookup simplified from a subquery through `course_to_lmss` to a direct `Assignment.where(course_id: @course.id)`.

The `course_to_lms_id` association is retained since it still carries LMS-specific linkage (external IDs, LMS type). An assignment's course never changes, so the denormalization is safe.

# Testing

- Migrated dev and test databases successfully.
- Full RSpec suite: **479 examples, 0 failures** (1 pre-existing unrelated pending).
- RuboCop clean on all changed files.
- Verified `course_id` auto-populates when an assignment is created with only `course_to_lms_id`, and that `Course#assignments` now emits a plain `WHERE course_id = ?` with no join.

# Documentation

No documentation changes required.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/fqRGWHjTJDWP/implementations/nJfJbQWGqRw9) | [App Preview](https://www.superconductor.com/tickets/fqRGWHjTJDWP/implementations/nJfJbQWGqRw9/preview) | [Guided Review](https://www.superconductor.com/tickets/fqRGWHjTJDWP/implementations/nJfJbQWGqRw9?tab=guided_review)

<!-- created-by-superconductor -->