### PR TITLE
Add course_id as a foreign key to the assignments table

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -103,7 +103,7 @@ class CoursesController < ApplicationController
     return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
     return redirect_to courses_path, alert: 'Extensions are enabled for this course.' if @course.course_settings&.enable_extensions
 
-    assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: @course.id).select(:id))
+    assignments = @course.assignments
     Extension.where(assignment_id: assignments.select(:id)).destroy_all
     assignments.destroy_all
     CourseToLms.where(course_id: @course.id).destroy_all

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -42,10 +42,10 @@ class RequestsController < ApplicationController
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
 
     if @role == 'instructor'
-      prepare_instructor_new_request(course_to_lmss)
+      prepare_instructor_new_request
       render :new_for_student and return
     elsif @role == 'student'
-      redirected = prepare_student_new_request(course_to_lmss)
+      redirected = prepare_student_new_request
       return if redirected
 
       render :new and return
@@ -61,7 +61,7 @@ class RequestsController < ApplicationController
     course_to_lmss = @course.all_linked_lmss.pluck(:id)
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
 
-    @assignments = Assignment.enabled_for_course(course_to_lmss).order(:name)
+    @assignments = @course.enabled_assignments.order(:name)
     @students = User.joins(:user_to_courses).where(user_to_courses: { course_id: @course.id, role: 'student' }).order(:name)
     @request = @course.requests.new
   end
@@ -209,7 +209,7 @@ class RequestsController < ApplicationController
 
   def handle_request_error
     flash.now[:alert] = 'There was a problem submitting your request.'
-    @assignments = Assignment.enabled_for_course(@course.all_linked_lmss.pluck(:id)).order(:name)
+    @assignments = @course.enabled_assignments.order(:name)
     @selected_assignment = Assignment.find_by(id: params[:assignment_id]) if params[:assignment_id]
     render :new
   end
@@ -292,14 +292,14 @@ class RequestsController < ApplicationController
     redirect_to result[:redirect_to], alert: result[:alert] if result != true
   end
 
-  def prepare_instructor_new_request(course_to_lms_ids)
+  def prepare_instructor_new_request
     @students = User.joins(:user_to_courses).where(user_to_courses: { course_id: @course.id, role: 'student' }).order(:name)
     @request = @course.requests.new
-    @assignments = Assignment.enabled_for_course(course_to_lms_ids).order(:name)
+    @assignments = @course.enabled_assignments.order(:name)
   end
 
-  def prepare_student_new_request(course_to_lms_ids)
-    all_assignments = Assignment.enabled_for_course(course_to_lms_ids).order(:name)
+  def prepare_student_new_request
+    all_assignments = @course.enabled_assignments.order(:name)
     @assignments = all_assignments.reject { |assignment| assignment.has_pending_request_for_user?(@user, @course) }
     @has_pending = all_assignments.size != @assignments.size
     @selected_assignment = Assignment.find_by(id: params[:assignment_id]) if params[:assignment_id]
@@ -323,7 +323,7 @@ class RequestsController < ApplicationController
   end
 
   def render_new_for_student_error
-    prepare_instructor_new_request(@course.all_linked_lmss.pluck(:id))
+    prepare_instructor_new_request
     flash.now[:alert] = 'There was a problem submitting the request.'
     render :new_for_student
   end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -10,16 +10,27 @@
 #  name                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  course_id              :bigint           not null
 #  course_to_lms_id       :bigint           not null
 #  external_assignment_id :string
 #
+# Indexes
+#
+#  index_assignments_on_course_id  (course_id)
+#
 # Foreign Keys
 #
+#  fk_rails_...  (course_id => courses.id)
 #  fk_rails_...  (course_to_lms_id => course_to_lmss.id)
 #
 class Assignment < ApplicationRecord
+  belongs_to :course
   belongs_to :course_to_lms
   has_many :requests, dependent: :destroy
+
+  # course_id is denormalized from course_to_lms so course-scoped queries
+  # don't need a join; default it so callers only have to set course_to_lms.
+  before_validation :set_course_from_course_to_lms
 
   validates :name, presence: true
   validates :external_assignment_id, presence: true
@@ -28,12 +39,13 @@ class Assignment < ApplicationRecord
 
   delegate :lms_id, to: :course_to_lms
 
-  # Returns enabled assignments for a specific course
-  scope :enabled_for_course, ->(course_to_lms_id) { where(course_to_lms_id: course_to_lms_id, enabled: true) }
-
   # Check if there's a pending request for this assignment by a specific user
   def has_pending_request_for_user?(user, course)
     requests.exists?(user: user, course: course, status: 'pending')
+  end
+
+  def set_course_from_course_to_lms
+    self.course ||= course_to_lms&.course
   end
 
   def enabled_requires_date_present

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -23,6 +23,9 @@ class Course < ApplicationRecord
   # TODO: after_initialize :build_course_settings_if_necessary
 
   # Associations
+  # Declared before course_to_lmss so a destroy removes assignments first,
+  # satisfying their FK on course_to_lms_id.
+  has_many :assignments, dependent: :destroy
   has_many :course_to_lmss, dependent: :destroy
   has_many :lmss, through: :course_to_lmss
   has_many :user_to_courses, dependent: :destroy
@@ -109,10 +112,6 @@ class Course < ApplicationRecord
     course_to_lms(1).present?
   end
 
-  def assignments
-    Assignment.where(course_to_lms: course_to_lmss).order(:name)
-  end
-
   def enabled_assignments
     assignments.where(enabled: true)
   end
@@ -154,11 +153,7 @@ class Course < ApplicationRecord
     CourseToLms.find_by(course_id: id, lms_id: GRADESCOPE_LMS_ID)&.external_course_id
   end
 
-  # TODO: Add specs for these 4 simple methods
-  def assignments
-    Assignment.joins(:course_to_lms).where(course_to_lms: { course_id: id })
-  end
-
+  # TODO: Add specs for these 3 simple methods
   def students
     user_to_courses.where(role: UserToCourse::STUDENT_ROLE).map(&:user)
   end

--- a/db/migrate/20260702000001_add_course_id_to_assignments.rb
+++ b/db/migrate/20260702000001_add_course_id_to_assignments.rb
@@ -1,0 +1,25 @@
+class AddCourseIdToAssignments < ActiveRecord::Migration[7.2]
+  # Assignments were only reachable from a course through course_to_lmss,
+  # so every course-scoped assignment query paid for a join. Denormalizing
+  # course_id onto assignments lets those queries hit an indexed FK directly.
+  def up
+    safety_assured do
+      add_reference :assignments, :course, foreign_key: true, index: true
+
+      # Backfill from the existing join table. course_to_lms_id is NOT NULL and
+      # CourseToLms requires a course, so this covers every row.
+      execute <<~SQL.squish
+        UPDATE assignments
+        SET course_id = course_to_lmss.course_id
+        FROM course_to_lmss
+        WHERE assignments.course_to_lms_id = course_to_lmss.id
+      SQL
+
+      change_column_null :assignments, :course_id, false
+    end
+  end
+
+  def down
+    remove_reference :assignments, :course, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_22_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_02_000001) do
   create_schema "hypershield"
 
   # These are extensions that must be enabled in order to support this database
@@ -30,6 +30,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_22_000001) do
     t.datetime "due_date"
     t.datetime "late_due_date"
     t.boolean "enabled", default: false
+    t.bigint "course_id", null: false
+    t.index ["course_id"], name: "index_assignments_on_course_id"
   end
 
   create_table "blazer_audits", force: :cascade do |t|
@@ -232,6 +234,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_22_000001) do
   end
 
   add_foreign_key "assignments", "course_to_lmss"
+  add_foreign_key "assignments", "courses"
   add_foreign_key "course_settings", "courses"
   add_foreign_key "course_to_lmss", "courses"
   add_foreign_key "course_to_lmss", "lmss"

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -9,11 +9,17 @@
 #  name                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  course_id              :bigint           not null
 #  course_to_lms_id       :bigint           not null
 #  external_assignment_id :string
 #
+# Indexes
+#
+#  index_assignments_on_course_id  (course_id)
+#
 # Foreign Keys
 #
+#  fk_rails_...  (course_id => courses.id)
 #  fk_rails_...  (course_to_lms_id => course_to_lmss.id)
 #
 require 'rails_helper'
@@ -21,6 +27,20 @@ require 'rails_helper'
 RSpec.describe Assignment, type: :model do
   it 'has a valid factory' do
     expect(build(:assignment)).to be_valid
+  end
+
+  describe 'course denormalization' do
+    it 'defaults course to the course_to_lms course on save' do
+      course = create(:course)
+      assignment = create(:assignment, course_to_lms: course.course_to_lms(1))
+      expect(assignment.course).to eq(course)
+    end
+
+    it 'is invalid without a course or course_to_lms' do
+      assignment = build(:assignment, course_to_lms: nil)
+      expect(assignment).not_to be_valid
+      expect(assignment.errors[:course]).to include('must exist')
+    end
   end
 
   describe 'custom validations' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe Course, type: :model do
     { "id": 240, "name": "Sherri Johnson", "created_at": "2025-05-05T11:57:36-07:00", "sortable_name": "Johnson, Sherri", "short_name": "Sherri Johnson", "sis_user_id": "216573718", "integration_id": "sherri.johnson53", "sis_import_id": 5, "login_id": "sherri.johnson53@example.com", "email": "sherri.johnson53@example.com", "has_non_collaborative_groups": false }
   ]
 
+  describe '#enabled_assignments' do
+    it 'returns only enabled assignments belonging to the course' do
+      course = create(:course)
+      other_course = create(:course)
+      enabled = create(:assignment, course_to_lms: course.course_to_lms(1), enabled: true)
+      create(:assignment, course_to_lms: course.course_to_lms(1), enabled: false)
+      create(:assignment, course_to_lms: other_course.course_to_lms(1), enabled: true)
+
+      expect(course.enabled_assignments).to contain_exactly(enabled)
+    end
+  end
+
   describe '#staff_user_for_auto_approval' do
     it 'returns the correct user for auto approval' do
       course = described_class.create!(canvas_id: 'canvas_123', course_name: 'Test', course_code: 'TEST101')


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Adds `course_id` as a denormalized foreign key on the `assignments` table so that course-scoped assignment queries hit a single indexed column instead of joining through `course_to_lmss`. This also enables a proper `has_many :assignments` association on `Course`, which simplifies call sites throughout the app.

**Why denormalize?** Assignments never change course, so drift risk is negligible. The real wins are:
- Eliminates a join/subquery on one of the app's most frequent lookups (request form, authorization checks, course delete, course page).
- Removes three different hand-rolled ways of expressing "assignments for a course" that had grown across the codebase — some of which only queried the Canvas LMS and silently missed Gradescope assignments.
- Makes `course.assignments` a real Active Record association that composes naturally with `includes`, `exists?`, etc.

**Key changes:**
- **Migration** ([`20260702000001_add_course_id_to_assignments.rb`](https://github.com/berkeley-cdss/flextensions/blob/cycomachead/178-add-course-id-fk/2/db/migrate/20260702000001_add_course_id_to_assignments.rb)): adds the indexed FK, backfills `course_id` from `course_to_lmss` in a single `UPDATE`, then marks it `NOT NULL`.
- **`Assignment` model** ([`app/models/assignment.rb`](https://github.com/berkeley-cdss/flextensions/blob/cycomachead/178-add-course-id-fk/2/app/models/assignment.rb)): adds `belongs_to :course` and a `before_validation` callback that defaults `course` from `course_to_lms`, so existing creation paths (sync jobs, API, factories) need no changes. Removes the `enabled_for_course` scope, which is now redundant.
- **`Course` model** ([`app/models/course.rb`](https://github.com/berkeley-cdss/flextensions/blob/cycomachead/178-add-course-id-fk/2/app/models/course.rb)): replaces two conflicting `assignments` instance method definitions (the second silently won) with a single `has_many :assignments`. Declared before `course_to_lmss` so `course.destroy` removes assignments before the join rows they reference — previously this would raise an FK violation.
- **Controllers** ([`requests_controller.rb`](https://github.com/berkeley-cdss/flextensions/blob/cycomachead/178-add-course-id-fk/2/app/controllers/requests_controller.rb), [`courses_controller.rb`](https://github.com/berkeley-cdss/flextensions/blob/cycomachead/178-add-course-id-fk/2/app/controllers/courses_controller.rb)): all assignment lookups now use `@course.enabled_assignments` or `@course.assignments` directly.

# Testing

- RSpec: 482 examples, 0 failures. Added specs for the `before_validation` backfill callback, the presence validation, and `Course#enabled_assignments` (moved from the now-deleted scope spec).
- RuboCop: clean.
- Cucumber: 18/23 scenarios pass. The 5 failing scenarios are JS/browser-environment tests confirmed to fail identically on unmodified `main` — pre-existing, not caused by this change.

# Documentation

No documentation changes required. The association follows standard Rails conventions.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/fqRGWHjTJDWP/implementations/HJf7kBmRkBBd) | [App Preview](https://www.superconductor.com/tickets/fqRGWHjTJDWP/implementations/HJf7kBmRkBBd/preview) | [Guided Review](https://www.superconductor.com/tickets/fqRGWHjTJDWP/implementations/HJf7kBmRkBBd?tab=guided_review)

<!-- created-by-superconductor -->