### PR TITLE
Review and debug CANVAS request approval logic for auto-approvals

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,9 +53,9 @@ class ApplicationController < ActionController::Base
     if session[:user_id].blank? || !Rails.env.test?
       if current_user.nil?
         return handle_authentication_failure('You must be logged in to access that page.')
-      elsif current_user.lms_credentials.empty?
+      elsif current_user.canvas_credentials.nil?
         return handle_authentication_failure('User has no credentials.')
-      elsif current_user.lms_credentials.first.expire_time < Time.zone.now
+      elsif current_user.canvas_credentials.expire_time < Time.zone.now
         # The Canvas access token has expired. Rather than logging the user out
         # immediately, try to use the stored (long-lived) refresh token to obtain
         # a fresh access token so the session can continue. We only log the user

--- a/app/controllers/concerns/token_refreshable.rb
+++ b/app/controllers/concerns/token_refreshable.rb
@@ -3,7 +3,7 @@ module TokenRefreshable
 
   # Ensure user has a valid token before making API calls
   def with_valid_token(user)
-    return yield(user.lms_credentials.first.token) unless user.token_expires_soon?
+    return yield(user.canvas_credentials.token) unless user.token_expires_soon?
 
     # Token is expiring soon, refresh it
     new_token = refresh_user_token(user)
@@ -22,8 +22,8 @@ module TokenRefreshable
 
   # This needs to be moved to the user model or CanvasFacade
   def refresh_user_token(user)
-    # Get the user's credentials
-    credential = user.lms_credentials.first
+    # Get the user's Canvas credential (the only kind we OAuth-refresh).
+    credential = user.canvas_credentials
     return unless credential&.refresh_token
 
     # TODO: Debug / test API scopes.

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -41,7 +41,7 @@ class CoursesController < ApplicationController
   end
 
   def new
-    token = @user.lms_credentials.first.token
+    token = @user.canvas_credentials.token
     @courses = Course.fetch_courses(token)
     flash[:alert] = 'No courses found.' if @courses.empty?
 
@@ -68,7 +68,7 @@ class CoursesController < ApplicationController
   end
 
   def create
-    token = @user.lms_credentials.first.token
+    token = @user.canvas_credentials.token
     filter_courses(Course.fetch_courses(token), UserToCourse.staff_roles)
       .select { |c| params[:courses]&.include?(c['id'].to_s) }
       .each { |course_api| Course.create_or_update_from_canvas(course_api, token, @user) }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -179,10 +179,17 @@ class Course < ApplicationRecord
     course_settings.destroy if course_settings
   end
 
-  # Find the first staff user who has a Canvas Token that can be used
-  # to post requests to Canvas.
+  # Find a staff user whose stored Canvas credentials can be used to post
+  # auto-approved extensions to Canvas on the course's behalf.
+  #
+  # Every Flextensions login is via Canvas OAuth, so only staff who have
+  # actually signed in have an LmsCredential. Staff who were pulled in by the
+  # roster sync but never logged in have none. Picking the first staff
+  # *enrollment* (the previous behavior) could therefore land on someone with
+  # no token, causing auto-approval to silently do nothing -- so we skip past
+  # those and return the first staff member who has Canvas credentials.
   def staff_user_for_auto_approval
-    user_to_courses.where(role: UserToCourse.staff_roles).first&.user
+    staff_users.find { |user| user.canvas_credentials.present? }
   end
 
   # Fetch courses from Canvas API

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -76,7 +76,6 @@ class Request < ApplicationRecord
   # Handle request update and check for auto-approval
   def process_update(_current_user)
     link = request_link
-    notify_slack = true
 
     if status == 'pending' && try_auto_approval(_current_user)
       slack_message = build_slack_message(:auto_approved, link)
@@ -86,8 +85,7 @@ class Request < ApplicationRecord
       result = build_result_hash('Request was successfully updated.')
     end
 
-    success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
-    Rails.logger.error "Failed to send Slack notification for request #{id} in course #{course.id}. Please check your webhook URL." unless success
+    notify_slack(slack_message)
     result
   end
 
@@ -96,16 +94,25 @@ class Request < ApplicationRecord
   end
 
   # Attempt to auto-approve by posting to the LMS.
+  # eligible_for_auto_approval? already includes the course-level check, so we
+  # don't repeat auto_approval_eligible_for_course? here.
   def try_auto_approval(_current_user)
-    return false unless auto_approval_eligible_for_course?
     return false unless eligible_for_auto_approval?
 
     approval_user = course.staff_user_for_auto_approval
-    approval_user.ensure_fresh_canvas_token!
-    return false if approval_user.canvas_credentials.blank?
+    if approval_user.nil?
+      # Previously this failed silently and the request just stayed pending with
+      # nothing posted to Canvas -- the production symptom we're chasing. Log it
+      # so a course whose staff never linked Canvas is diagnosable.
+      Rails.logger.error(
+        "Auto-approval could not run for request #{id} in course #{course.id}: " \
+        'no staff member has linked Canvas credentials to post the extension.'
+      )
+      return false
+    end
 
-    lms_facade_from_user = assignment.lms_facade.from_user(approval_user)
-    auto_approve(lms_facade_from_user)
+    approval_user.ensure_fresh_canvas_token!
+    auto_approve(assignment.lms_facade.from_user(approval_user))
   end
 
   def auto_approval_eligible_for_course?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,15 +64,20 @@ class User < ApplicationRecord
     false
   end
 
-  # Get active token or refresh if needed
+  # Returns a currently-valid Canvas access token for this user, refreshing it
+  # via the stored refresh token when it has (nearly) expired. Returns nil when
+  # the user has no Canvas credential -- e.g. a staff member who was rostered
+  # from Canvas but never signed into Flextensions.
   def ensure_fresh_canvas_token!
-    return nil unless lms_credentials.any?
-
-    credential = lms_credentials.first
+    credential = canvas_credentials
+    return nil unless credential
 
     if token_expires_soon?
-      # Call the refresh token method from SessionController
+      # refresh_user_token persists a fresh token on the credential row when the
+      # refresh succeeds; reload so we hand back that value rather than the stale
+      # one we read a moment ago.
       SessionController.new.send(:refresh_user_token, self)
+      credential.reload
     end
 
     credential.token

--- a/lib/lmss/base_override.rb
+++ b/lib/lmss/base_override.rb
@@ -1,7 +1,10 @@
 module Lmss
   class BaseOverride
     def id = raise(NotImplementedError)
-    def student_id = raise(NotImplementedError)
+    # The students an override targets. Canvas adhoc overrides target a list,
+    # Gradescope overrides a single student; both answer this as an array so
+    # callers can treat overrides uniformly.
+    def student_ids = raise(NotImplementedError)
     def override_release_date = raise(NotImplementedError)
     def override_due_date = raise(NotImplementedError)
     def override_late_due_date = raise(NotImplementedError)

--- a/lib/lmss/gradescope/override.rb
+++ b/lib/lmss/gradescope/override.rb
@@ -12,6 +12,12 @@ module Lmss
         @override_late_due_date = data.dig('override', 'settings', 'hard_due_date', 'value')
       end
 
+      # A Gradescope override targets exactly one student; expose it as a list
+      # to satisfy the shared BaseOverride#student_ids contract.
+      def student_ids
+        [ student_id ]
+      end
+
       private
 
       def parse_id(raw_id)

--- a/lib/tasks/validate_canvas_extensions.rake
+++ b/lib/tasks/validate_canvas_extensions.rake
@@ -1,0 +1,50 @@
+# Rerunnable Canvas extension validation.
+#
+# Exercises the REAL production code path (CanvasFacade#provision_extension) so
+# you can confirm that extensions are correctly written to Canvas for every
+# assignment type -- plain assignments, graded discussions, classic quizzes, and
+# New Quizzes -- rather than only unit-testing it with mocks.
+#
+# It never persists the token: pass it in the environment for a single run.
+#
+# Usage (from the repo root):
+#
+#   CANVAS_URL=https://ucberkeleysandbox.instructure.com \
+#   CANVAS_TOKEN=xxxxx \
+#   COURSE_ID=<canvas_course_id> \
+#   STUDENT_ID=<canvas_user_id> \
+#   ASSIGNMENT_IDS=<id1,id2,...> \
+#   DUE_AT=2026-08-01T23:59:00Z \
+#   bundle exec rails canvas:validate_extensions
+#
+# ASSIGNMENT_IDS accepts the *assignment* id shown by the assignments endpoint.
+# Graded discussions and New Quizzes expose an assignment id there and work
+# directly. Classic quizzes expose a quiz_id too; include the assignment id and
+# watch for a failure, which would confirm the classic-quiz gap (the app has no
+# write scope for /quizzes/:quiz_id/assignment_overrides).
+namespace :canvas do
+  desc 'Provision a test extension for each ASSIGNMENT_IDS via the real CanvasFacade'
+  task validate_extensions: :environment do
+    token = ENV.fetch('CANVAS_TOKEN')
+    course_id = ENV.fetch('COURSE_ID')
+    student_id = ENV.fetch('STUDENT_ID')
+    assignment_ids = ENV.fetch('ASSIGNMENT_IDS').split(',').map(&:strip).reject(&:empty?)
+    due_at = ENV.fetch('DUE_AT', 1.week.from_now.iso8601)
+    late_due_at = ENV['LATE_DUE_AT'].presence
+
+    facade = CanvasFacade.new(token)
+
+    puts "Canvas:   #{CanvasFacade::CANVAS_URL}"
+    puts "Course:   #{course_id}"
+    puts "Student:  #{student_id}"
+    puts "New due:  #{due_at}#{" (late: #{late_due_at})" if late_due_at}"
+    puts '-' * 60
+
+    assignment_ids.each do |assignment_id|
+      override = facade.provision_extension(course_id, student_id, assignment_id, due_at, late_due_at)
+      puts "OK   assignment #{assignment_id}: override ##{override.id}"
+    rescue StandardError => e
+      puts "FAIL assignment #{assignment_id}: #{e.class} - #{e.message}"
+    end
+  end
+end

--- a/spec/controllers/concerns/token_refreshable_spec.rb
+++ b/spec/controllers/concerns/token_refreshable_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe TokenRefreshable, type: :controller do
   describe '#with_valid_token' do
     context 'when token is not expiring soon' do
       it 'yields with current token' do
-        user_double = instance_double(User, lms_credentials: user.lms_credentials, token_expires_soon?: false)
+        user_double = instance_double(User, canvas_credentials: user.canvas_credentials, token_expires_soon?: false)
 
         allow(controller).to receive(:current_user).and_return(user_double)
 
@@ -73,7 +73,7 @@ RSpec.describe TokenRefreshable, type: :controller do
 
         get :dummy_action
         expect(response.body).to eq('Token: refreshed_token')
-        expect(user.lms_credentials.first.reload.token).to eq('refreshed_token')
+        expect(user.canvas_credentials.token).to eq('refreshed_token')
       end
     end
 

--- a/spec/lmss/base_override_spec.rb
+++ b/spec/lmss/base_override_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+# Both LMS override POROs must answer the shared BaseOverride#student_ids
+# contract with an array, so callers can treat overrides uniformly regardless
+# of LMS (Canvas targets a list of students, Gradescope a single student).
+RSpec.describe Lmss::BaseOverride do
+  it 'Canvas::Override exposes the targeted students as an array' do
+    override = Lmss::Canvas::Override.new(
+      OpenStruct.new(id: 1, title: '1 day extension', student_ids: [ 42, 43 ],
+                     unlock_at: nil, due_at: nil, lock_at: nil)
+    )
+    expect(override.student_ids).to eq([ 42, 43 ])
+  end
+
+  it 'Gradescope::Override wraps its single student in an array' do
+    override = Lmss::Gradescope::Override.new(
+      'deletePath' => '/courses/1/assignments/2/extensions/99',
+      'override' => { 'user_id' => 42, 'settings' => {} }
+    )
+    expect(override.student_id).to eq(42)
+    expect(override.student_ids).to eq([ 42 ])
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -38,19 +38,44 @@ RSpec.describe Course, type: :model do
   ]
 
   describe '#staff_user_for_auto_approval' do
-    it 'returns the correct user for auto approval' do
-      course = described_class.create!(canvas_id: 'canvas_123', course_name: 'Test', course_code: 'TEST101')
-      user = User.create!(email: 'test@example.com', canvas_uid: '123')
+    let(:course) { described_class.create!(canvas_id: 'canvas_123', course_name: 'Test', course_code: 'TEST101') }
+
+    def link_canvas_credential(user)
       user.lms_credentials.create!(
         lms_name: 'canvas',
         token: 'valid_token',
         refresh_token: 'refresh_token',
         expire_time: 1.hour.from_now
       )
+    end
+
+    it 'returns a staff user who has Canvas credentials' do
+      user = User.create!(email: 'test@example.com', canvas_uid: '123')
+      link_canvas_credential(user)
       UserToCourse.create!(user: user, course: course, role: 'ta')
 
-      staff_user = course.staff_user_for_auto_approval
-      expect(staff_user).to eq(user)
+      expect(course.staff_user_for_auto_approval).to eq(user)
+    end
+
+    # Regression for the production bug: the first staff enrollment belonged to a
+    # TA who was rostered from Canvas but never signed into Flextensions, so they
+    # had no token. Auto-approval must skip them and use a staff member who does.
+    it 'skips staff members who never linked Canvas credentials' do
+      no_token_ta = User.create!(email: 'rostered@example.com', canvas_uid: '111')
+      UserToCourse.create!(user: no_token_ta, course: course, role: 'ta')
+
+      logged_in_teacher = User.create!(email: 'teacher@example.com', canvas_uid: '222')
+      link_canvas_credential(logged_in_teacher)
+      UserToCourse.create!(user: logged_in_teacher, course: course, role: 'teacher')
+
+      expect(course.staff_user_for_auto_approval).to eq(logged_in_teacher)
+    end
+
+    it 'returns nil when no staff member has linked Canvas credentials' do
+      no_token_ta = User.create!(email: 'rostered@example.com', canvas_uid: '111')
+      UserToCourse.create!(user: no_token_ta, course: course, role: 'ta')
+
+      expect(course.staff_user_for_auto_approval).to be_nil
     end
   end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -508,6 +508,26 @@ RSpec.describe Request, type: :model do
         expect(request.try_auto_approval(user)).to be false
       end
     end
+
+    # Regression for the production bug: when no course staff member has linked
+    # Canvas credentials there is nobody to post the extension as. This must fail
+    # gracefully (and audibly) instead of raising NoMethodError on nil.
+    context 'when no staff member has usable Canvas credentials' do
+      before do
+        allow(request).to receive_messages(eligible_for_auto_approval?: true, course: course)
+        allow(course).to receive(:staff_user_for_auto_approval).and_return(nil)
+      end
+
+      it 'returns false without calling auto_approve' do
+        expect(request).not_to receive(:auto_approve)
+        expect(request.try_auto_approval(nil)).to be false
+      end
+
+      it 'logs an error explaining why auto-approval could not run' do
+        expect(Rails.logger).to receive(:error).with(/no staff member has linked Canvas credentials/)
+        request.try_auto_approval(nil)
+      end
+    end
   end
 
   describe '#auto_approve' do
@@ -748,6 +768,41 @@ RSpec.describe Request, type: :model do
     it 'sets the last_processed_by_user_id' do
       request.reject(instructor)
       expect(request.last_processed_by_user_id).to eq(instructor.id)
+    end
+  end
+
+  describe '#process_update' do
+    before { allow(request).to receive(:try_auto_approval).and_return(false) }
+
+    context 'when the course has no Slack webhook configured' do
+      it 'does not attempt a Slack notification' do
+        expect(SlackNotifier).not_to receive(:notify)
+        request.process_update(instructor)
+      end
+
+      # Regression: the old inline block left `success` nil when there was no
+      # webhook, so it logged a spurious "Failed to send Slack notification"
+      # error for every update on a course that never set one up.
+      it 'does not log a Slack failure error' do
+        expect(Rails.logger).not_to receive(:error)
+        request.process_update(instructor)
+      end
+    end
+
+    context 'when a Slack webhook is configured' do
+      before { course.course_settings.update!(slack_webhook_url: 'https://hooks.slack.example/abc') }
+
+      it 'sends the notification and does not log an error on success' do
+        expect(SlackNotifier).to receive(:notify).and_return(true)
+        expect(Rails.logger).not_to receive(:error)
+        request.process_update(instructor)
+      end
+
+      it 'logs an error when the notification fails' do
+        allow(SlackNotifier).to receive(:notify).and_return(false)
+        expect(Rails.logger).to receive(:error).with(/Failed to send Slack notification/)
+        request.process_update(instructor)
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe User, type: :model do
   describe '#ensure_fresh_canvas_token!' do
     let(:user) { described_class.create!(email: 'test@example.com', canvas_uid: '123') }
 
+    context 'when the user has no Canvas credential' do
+      it 'returns nil' do
+        expect(user.ensure_fresh_canvas_token!).to be_nil
+      end
+    end
+
     context 'when token does not expire soon' do
       before do
         user.lms_credentials.create!(
@@ -89,13 +95,14 @@ RSpec.describe User, type: :model do
         )
       end
 
-      it 'returns the current token' do
+      it 'returns the current token without refreshing' do
+        expect_any_instance_of(SessionController).not_to receive(:refresh_user_token)
         expect(user.ensure_fresh_canvas_token!).to eq('valid_token')
       end
     end
 
     context 'when token expires soon and is refreshed' do
-      let(:credential) do
+      let!(:credential) do
         user.lms_credentials.create!(
           lms_name: 'canvas',
           token: 'stale_token',
@@ -104,16 +111,39 @@ RSpec.describe User, type: :model do
         )
       end
 
-      before { credential }
-
-      it 'refreshes token and returns it' do
+      # Simulate the real SessionController#refresh_user_token, which persists a
+      # fresh token to the credential row when the refresh succeeds.
+      before do
         allow(user).to receive(:token_expires_soon?).and_return(true)
+        allow_any_instance_of(SessionController).to receive(:refresh_user_token) do
+          credential.update!(token: 'refreshed_token', expire_time: 1.hour.from_now)
+          'refreshed_token'
+        end
+      end
 
-        allow_any_instance_of(SessionController).to receive(:refresh_user_token).and_return('refreshed_token')
+      it 'returns the refreshed token, not the stale one' do
+        # Regression: previously this returned the stale in-memory token even
+        # after a successful refresh, so callers (e.g. the roster sync job and
+        # auto-approval) posted to Canvas with an about-to-expire token.
+        expect(user.ensure_fresh_canvas_token!).to eq('refreshed_token')
+      end
+    end
 
-        result = user.ensure_fresh_canvas_token!
+    context 'when the Canvas credential is not the first credential' do
+      before do
+        # A non-Canvas credential ordered ahead of the Canvas one; the previous
+        # implementation grabbed lms_credentials.first and returned the wrong token.
+        user.lms_credentials.create!(lms_name: 'other', token: 'other_token', expire_time: 1.hour.from_now)
+        user.lms_credentials.create!(
+          lms_name: 'canvas',
+          token: 'canvas_token',
+          refresh_token: 'refresh_token',
+          expire_time: 1.hour.from_now
+        )
+      end
 
-        expect(result).to eq('stale_token') # Still returns the credential.token
+      it 'returns the Canvas token' do
+        expect(user.ensure_fresh_canvas_token!).to eq('canvas_token')
       end
     end
   end


### PR DESCRIPTION
# Fix Canvas auto-approval failures and harden credential selection

Resolves a production bug where Canvas auto-approvals silently failed to post extensions, while manual approvals and Gradescope auto-approvals continued working. The root cause was `staff_user_for_auto_approval` returning the first staff *enrollment* regardless of whether that person had ever signed into Flextensions — staff rostered via sync but who never logged in have no `LmsCredential`, so the extension was never posted and the request stayed pending with no error logged.

- [ ] Breaking?

# Changes

**Root cause fix (`course.rb`, `request.rb`, `user.rb`)**
- `Course#staff_user_for_auto_approval` now skips staff with no Canvas credentials and returns the first who does (previously returned the first enrollment unconditionally).
- `Request#try_auto_approval` handles a `nil` approval user explicitly with a logged error instead of silently doing nothing or raising `NoMethodError`.
- `User#ensure_fresh_canvas_token!` now targets `canvas_credentials` specifically (not `lms_credentials.first`) and calls `credential.reload` after refresh so it returns the genuinely fresh token rather than the stale in-memory value.

**Credential targeting (`application_controller.rb`, `token_refreshable.rb`, `courses_controller.rb`)**
- `authenticated!`, `with_valid_token`, `refresh_user_token`, and the course `new`/`create` actions all now read from `canvas_credentials` instead of `lms_credentials.first` — eliminating the same latent bug class in the auth/token-refresh path.

**Slack fix (`request.rb`)**
- Removed a dead `notify_slack = true` local variable and replaced duplicated inline notification logic with the existing private `notify_slack` helper. This also fixes a latent bug where `success` was `nil` for courses with no webhook configured, causing a spurious "Failed to send Slack notification" error on every update.

**Interface alignment (`base_override.rb`, `gradescope/override.rb`)**
- `BaseOverride` now declares `student_ids` (array) as the abstract method. `Gradescope::Override` adds `student_ids` returning `[student_id]` so both LMS override types satisfy one contract.

**Sandbox validation (`lib/tasks/validate_canvas_extensions.rake`)**
- Added a rerunnable Rake task that drives the real `CanvasFacade#provision_extension` code path against a live Canvas instance for any set of assignment IDs. Confirmed working against the ucberkeleysandbox for plain assignments, graded discussions, and classic quizzes (all use assignment overrides correctly). Token is read from the environment and never persisted.

# Testing

**Where testing gaps let the original bug through:**
- `user_spec.rb` literally asserted the bug as correct: `expect(result).to eq('stale_token') # Still returns the credential.token`
- `course_spec.rb` only tested `staff_user_for_auto_approval` with a single staff user who had a token — never the multi-staff / credential-less case that occurs in production.
- The `request_spec.rb` case "when user has no LMS credentials" passed via the `auto_approve_days: 0` limit, not the credential path, giving false confidence.
- `process_update`/Slack had zero test coverage.

**New/updated tests:**
- `course_spec`: skips credential-less staff; returns `nil` when no staff qualifies (regression cases fail on old code).
- `user_spec`: returns `nil` with no credential; returns refreshed token (not stale); picks Canvas credential even when it isn't `first`.
- `request_spec`: `try_auto_approval` fails gracefully and logs an error when `staff_user_for_auto_approval` returns `nil`; four `process_update` cases covering no-webhook (no notify, no error) and webhook (success/failure).
- `base_override_spec`: new spec locking in the `student_ids` array contract for both LMS types.
- `token_refreshable_spec`: updated doubles to use `canvas_credentials`.

**Suite: 491 examples, 0 failures, 1 pre-existing pending. Rubocop clean.**

# Documentation

The `validate_canvas_extensions.rake` file includes inline usage documentation. The Canvas sandbox test data created during validation:
- Course 146 "Flextensions Test Course": https://ucberkeleysandbox.instructure.com/courses/146
- Graded discussion (assignment 206): https://ucberkeleysandbox.instructure.com/courses/146/discussion_topics/109
- Classic quiz (assignment 207): https://ucberkeleysandbox.instructure.com/courses/146/quizzes/123

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/G9HjwNKWwkbC/implementations/rLqtjM6NH9hP) | [App Preview](https://www.superconductor.com/tickets/G9HjwNKWwkbC/implementations/rLqtjM6NH9hP/preview) | [Guided Review](https://www.superconductor.com/tickets/G9HjwNKWwkbC/implementations/rLqtjM6NH9hP?tab=guided_review)

<!-- created-by-superconductor -->