### PR TITLE
Refactor: Rename UserToCourse to Enrollment (Fable 5)

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -43,16 +43,16 @@ module API
         end
 
         # Check if the user has been already added to the course
-        existing_user_to_course = UserToCourse.find_by(course_id: course_id, user_id: user_id)
-        if existing_user_to_course
+        existing_enrollment = Enrollment.find_by(course_id: course_id, user_id: user_id)
+        if existing_enrollment
           render json: { error: 'The user is already added to the course.' }, status: :unprocessable_content
           return
         end
 
         # Add the user to the course with the desired role
-        new_user_to_course = UserToCourse.new(course_id: course_id, user_id: user_id, role: role)
-        new_user_to_course.save
-        render_response(new_user_to_course,
+        new_enrollment = Enrollment.new(course_id: course_id, user_id: user_id, role: role)
+        new_enrollment.save
+        render_response(new_enrollment,
                         'User added to the course successfully.',
                         'Failed to add the user the to course.')
       end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,12 +5,12 @@ class CoursesController < ApplicationController
   before_action :determine_user_role
 
   def index
-    teacher_courses = UserToCourse.includes(:course).where(user: @user, role: UserToCourse.staff_roles)
+    teacher_courses = Enrollment.includes(:course).where(user: @user, role: Enrollment.staff_roles)
     @teacher_courses_by_semester = group_by_semester(teacher_courses)
 
     # Only show courses to students if extensions are enabled at the course level
-    student_courses = UserToCourse.includes(course: :course_settings).where(user: @user, role: 'student')
-    visible_student_courses = student_courses.select { |utc| utc.course.requests_enabled? }
+    student_courses = Enrollment.includes(course: :course_settings).where(user: @user, role: 'student')
+    visible_student_courses = student_courses.select { |enrollment| enrollment.course.requests_enabled? }
     @student_courses_by_semester = group_by_semester(visible_student_courses)
 
     # Keep flat lists for conditional checks in the view
@@ -47,10 +47,10 @@ class CoursesController < ApplicationController
     # TODO: Add spec for when a course is created, but the user is not enrolled in it.
     # TODO: Why do some courses have empty enrollments?
     existing_canvas_ids = @user.courses.pluck(:canvas_id)
-    @courses_teacher = filter_courses(@courses, UserToCourse.staff_roles, existing_canvas_ids)
+    @courses_teacher = filter_courses(@courses, Enrollment.staff_roles, existing_canvas_ids)
     # Track if any teacher courses, so we still show the semester filter even if the selected semester filters out all courses.
     @has_any_teacher_courses = @courses_teacher.any?
-    @courses_student = filter_courses(@courses, [ UserToCourse::STUDENT_ROLE ], existing_canvas_ids)
+    @courses_student = filter_courses(@courses, [ Enrollment::STUDENT_ROLE ], existing_canvas_ids)
 
     if @selected_semester.present?
       @courses_teacher = filter_by_semester(@courses_teacher, @selected_semester)
@@ -65,7 +65,7 @@ class CoursesController < ApplicationController
 
   def create
     token = @user.lms_credentials.first.token
-    filter_courses(Course.fetch_courses(token), UserToCourse.staff_roles)
+    filter_courses(Course.fetch_courses(token), Enrollment.staff_roles)
       .select { |c| params[:courses]&.include?(c['id'].to_s) }
       .each { |course_api| Course.create_or_update_from_canvas(course_api, token, @user) }
     redirect_to courses_path, notice: 'Selected courses and their assignments have been imported successfully.'
@@ -90,7 +90,7 @@ class CoursesController < ApplicationController
     @side_nav = 'enrollments'
     return redirect_to courses_path, alert: 'You do not have access to this page.' unless @role == 'instructor'
 
-    @enrollments = @course.user_to_courses.includes(:user)
+    @enrollments = @course.enrollments.includes(:user)
     @is_course_admin = @course.course_admin?(@user)
     @enrollments_last_synced_at = enrollments_last_synced_at
   end
@@ -103,11 +103,11 @@ class CoursesController < ApplicationController
     Extension.where(assignment_id: assignments.select(:id)).destroy_all
     assignments.destroy_all
     CourseToLms.where(course_id: @course.id).destroy_all
-    UserToCourse.where(course_id: @course.id).destroy_all
+    Enrollment.where(course_id: @course.id).destroy_all
     Request.where(course_id: @course.id).destroy_all
     CourseSettings.where(course_id: @course.id).destroy_all
     FormSetting.where(course_id: @course.id).destroy_all
-    Course.where.missing(:user_to_courses).destroy_all
+    Course.where.missing(:enrollments).destroy_all
 
     redirect_to courses_path, notice: 'Course deleted successfully.'
   end
@@ -144,10 +144,10 @@ class CoursesController < ApplicationController
     @is_course_admin = @course&.course_admin?(@user) || false
   end
 
-  # Groups UserToCourse records by their course's semester, sorted most-recent-first.
-  # Returns an array of [semester_name, [user_to_courses]] pairs.
-  def group_by_semester(user_to_courses)
-    grouped = user_to_courses.group_by { |utc| utc.course.semester }
+  # Groups Enrollment records by their course's semester, sorted most-recent-first.
+  # Returns an array of [semester_name, [enrollments]] pairs.
+  def group_by_semester(enrollments)
+    grouped = enrollments.group_by { |enrollment| enrollment.course.semester }
     sorted_semesters = Course.sort_semesters(grouped.keys)
     sorted_semesters.map { |semester| [ semester, grouped[semester] ] }
   end
@@ -168,7 +168,7 @@ class CoursesController < ApplicationController
     return [] if courses.empty?
 
     courses.select do |course|
-      course['enrollments'].any? { |enrollment| roles.include?(UserToCourse.role_from_canvas_enrollment(enrollment)) }
+      course['enrollments'].any? { |enrollment| roles.include?(Enrollment.role_from_canvas_enrollment(enrollment)) }
     end
   end
 

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -1,10 +1,10 @@
-class UserToCoursesController < ApplicationController
+class EnrollmentsController < ApplicationController
   before_action :authenticate_user
   before_action :set_course
   before_action :ensure_course_admin
 
   def toggle_allow_extended_requests
-    @enrollment = @course.user_to_courses.find(params[:id])
+    @enrollment = @course.enrollments.find(params[:id])
 
     if @enrollment.update(allow_extended_requests: params[:allow_extended_requests])
       render json: { success: true }, status: :ok
@@ -17,7 +17,7 @@ class UserToCoursesController < ApplicationController
   private
 
   def ensure_course_admin
-    enrollment = @course.user_to_courses.find_by(user: @user)
+    enrollment = @course.enrollments.find_by(user: @user)
     return if enrollment&.course_admin?
 
     render json: { error: 'You must be an instructor or Lead TA.', redirect_to: course_path(@course) }, status: :forbidden

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -62,7 +62,7 @@ class RequestsController < ApplicationController
     return redirect_to courses_path, alert: 'No Canvas LMS data found for this course.' unless course_to_lmss.any?
 
     @assignments = @course.enabled_assignments.order(:name)
-    @students = User.joins(:user_to_courses).where(user_to_courses: { course_id: @course.id, role: 'student' }).order(:name)
+    @students = User.joins(:enrollments).where(enrollments: { course_id: @course.id, role: 'student' }).order(:name)
     @request = @course.requests.new
   end
 
@@ -293,7 +293,7 @@ class RequestsController < ApplicationController
   end
 
   def prepare_instructor_new_request
-    @students = User.joins(:user_to_courses).where(user_to_courses: { course_id: @course.id, role: 'student' }).order(:name)
+    @students = User.joins(:enrollments).where(enrollments: { course_id: @course.id, role: 'student' }).order(:name)
     @request = @course.requests.new
     @assignments = @course.enabled_assignments.order(:name)
   end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -104,8 +104,8 @@ class SessionController < ApplicationController
 
     # Ensure enrollment in the test course (as student so they can request extensions)
     if test_course
-      UserToCourse.find_or_create_by!(user_id: user.id, course_id: test_course.id) do |utc|
-        utc.role = 'student'
+      Enrollment.find_or_create_by!(user_id: user.id, course_id: test_course.id) do |enrollment|
+        enrollment.role = 'student'
       end
     end
   end

--- a/app/facades/canvas_facade.rb
+++ b/app/facades/canvas_facade.rb
@@ -10,7 +10,7 @@ class CanvasFacade < LmsFacade
 
   CANVAS_URL = ENV.fetch('CANVAS_URL', nil)
   CANVAS_CUSTOM_COURSE_ROLES = {
-    UserToCourse::LEAD_TA_ROLE => 'Lead TA'
+    Enrollment::LEAD_TA_ROLE => 'Lead TA'
   }.freeze
 
   # Canvas instances can scope the flextensions developer key.
@@ -200,7 +200,7 @@ class CanvasFacade < LmsFacade
   end
 
   def role_query_param(role)
-    normalized_role = UserToCourse.normalize_role(role)
+    normalized_role = Enrollment.normalize_role(role)
     canvas_course_role = CANVAS_CUSTOM_COURSE_ROLES[normalized_role]
 
     if canvas_course_role

--- a/app/jobs/sync_users_from_canvas_job.rb
+++ b/app/jobs/sync_users_from_canvas_job.rb
@@ -42,16 +42,16 @@ class SyncUsersFromCanvasJob < ApplicationJob
     users_updated = 0
 
     # Handle removals - only for the current role
-    existing_role_enrollments = UserToCourse.joins(:user)
+    existing_role_enrollments = Enrollment.joins(:user)
                                            .where(course_id: course.id, role: role)
-                                           .select('user_to_courses.*, users.canvas_uid')
+                                           .select('enrollments.*, users.canvas_uid')
 
-    enrollments_to_remove = existing_role_enrollments.reject do |utc|
-      current_canvas_user_ids.include?(utc.canvas_uid)
+    enrollments_to_remove = existing_role_enrollments.reject do |enrollment|
+      current_canvas_user_ids.include?(enrollment.canvas_uid)
     end
 
     if enrollments_to_remove.any?
-      UserToCourse.where(id: enrollments_to_remove.map(&:id)).destroy_all
+      Enrollment.where(id: enrollments_to_remove.map(&:id)).destroy_all
       users_removed = enrollments_to_remove.size
     end
 
@@ -91,7 +91,7 @@ class SyncUsersFromCanvasJob < ApplicationJob
 
     # Get existing enrollments to avoid duplicates
     existing_user_ids = users_by_canvas_uid.values.map(&:id)
-    existing_enrollments = UserToCourse.where(
+    existing_enrollments = Enrollment.where(
       user_id: existing_user_ids,
       course_id: course.id,
       role: role
@@ -115,7 +115,7 @@ class SyncUsersFromCanvasJob < ApplicationJob
 
     if enrollments_to_create.any?
       begin
-        UserToCourse.insert_all(enrollments_to_create)
+        Enrollment.insert_all(enrollments_to_create)
       rescue => e
         Rails.logger.debug { "DEBUG: Insert failed: #{e.message}" }
         Rails.logger.debug { "DEBUG: #{e.backtrace.first(3)}" }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -29,12 +29,12 @@ class Course < ApplicationRecord
   has_many :assignments, dependent: :destroy
   has_many :course_to_lmss, dependent: :destroy
   has_many :lmss, through: :course_to_lmss
-  has_many :user_to_courses, dependent: :destroy
+  has_many :enrollments, dependent: :destroy
   has_one :form_setting, dependent: :destroy
   has_one :course_settings, dependent: :destroy
   has_many :requests, dependent: :destroy
 
-  has_many :users, through: :user_to_courses
+  has_many :users, through: :enrollments
 
   validates :course_name, presence: true
 
@@ -123,23 +123,23 @@ class Course < ApplicationRecord
   # TODO: Replace this with staff_role?(user) or student_role?(user)
   # Or is user.staff_role?(course) or user.student_role?(course) better?
   def user_role(user)
-    roles = UserToCourse.where(user_id: user.id, course_id: id).pluck(:role)
-    return 'instructor' if roles.intersect?(UserToCourse.staff_roles)
-    return 'student' if roles.include?(UserToCourse::STUDENT_ROLE)
+    roles = Enrollment.where(user_id: user.id, course_id: id).pluck(:role)
+    return 'instructor' if roles.intersect?(Enrollment.staff_roles)
+    return 'student' if roles.include?(Enrollment::STUDENT_ROLE)
 
     nil
   end
 
   def course_admin?(user)
-    user_to_courses.where(user_id: user.id).any?(&:course_admin?)
+    enrollments.where(user_id: user.id).any?(&:course_admin?)
   end
 
   def course_staff?(user)
-    user_to_courses.where(user_id: user.id).any?(&:staff?)
+    enrollments.where(user_id: user.id).any?(&:staff?)
   end
 
   def course_student?(user)
-    user_to_courses.where(user_id: user.id).any?(&:student?)
+    enrollments.where(user_id: user.id).any?(&:student?)
   end
 
   # TODO: This doesn't make sense actually.
@@ -159,15 +159,15 @@ class Course < ApplicationRecord
 
   # TODO: Add specs for these 3 simple methods
   def students
-    user_to_courses.where(role: UserToCourse::STUDENT_ROLE).map(&:user)
+    enrollments.where(role: Enrollment::STUDENT_ROLE).map(&:user)
   end
 
   def instructors
-    user_to_courses.where(role: UserToCourse::TEACHER_ROLE).map(&:user)
+    enrollments.where(role: Enrollment::TEACHER_ROLE).map(&:user)
   end
 
   def staff_users
-    user_to_courses.where(role: UserToCourse.staff_roles).map(&:user)
+    enrollments.where(role: Enrollment.staff_roles).map(&:user)
   end
 
   # Staff users with Canvas credentials on file, most recently refreshed
@@ -263,14 +263,14 @@ class Course < ApplicationRecord
     end
   end
 
-  # Fetch users for a course and create/find their User and UserToCourse records
+  # Fetch users for a course and create/find their User and Enrollment records
   # TODO: This may need to become a background job
   def sync_users_from_canvas(user, roles = [ 'student' ])
     SyncUsersFromCanvasJob.perform_now(id, user, roles)
   end
 
   def sync_all_enrollments_from_canvas(user)
-    sync_users_from_canvas(user, UserToCourse.roles)
+    sync_users_from_canvas(user, Enrollment.roles)
   end
 
   def regenerate_readonly_api_token_if_blank

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: user_to_courses
+# Table name: enrollments
 #
 #  id                      :bigint           not null, primary key
 #  allow_extended_requests :boolean          default(FALSE), not null
@@ -13,16 +13,15 @@
 #
 # Indexes
 #
-#  index_user_to_courses_on_course_id  (course_id)
-#  index_user_to_courses_on_user_id    (user_id)
+#  index_enrollments_on_course_id  (course_id)
+#  index_enrollments_on_user_id    (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (course_id => courses.id)
 #  fk_rails_...  (user_id => users.id)
 #
-# TODO: In the future we should name this CourseEnrollment
-class UserToCourse < ApplicationRecord
+class Enrollment < ApplicationRecord
   STUDENT_ROLE = 'student'.freeze
   TEACHER_ROLE = 'teacher'.freeze
   TA_ROLE = 'ta'.freeze
@@ -45,11 +44,11 @@ class UserToCourse < ApplicationRecord
 
 
   def staff?
-    UserToCourse.staff_roles.include?(role)
+    Enrollment.staff_roles.include?(role)
   end
 
   def course_admin?
-    UserToCourse.course_admin_roles.include?(role)
+    Enrollment.course_admin_roles.include?(role)
   end
 
   def student?
@@ -57,11 +56,11 @@ class UserToCourse < ApplicationRecord
   end
 
   def display_role
-    UserToCourse.display_role(role)
+    Enrollment.display_role(role)
   end
 
   def self.roles
-    [ STUDENT_ROLE ] + UserToCourse.staff_roles
+    [ STUDENT_ROLE ] + Enrollment.staff_roles
   end
 
   def self.staff_roles

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -139,7 +139,7 @@ class Request < ApplicationRecord
     return false unless auto_approval_eligible_for_course?
     return false unless meets_min_hours_before_deadline?
 
-    enrollment = UserToCourse.find_by(user: user, course: course)
+    enrollment = Enrollment.find_by(user: user, course: course)
     return false if enrollment.nil?
     if enrollment.allow_extended_requests
       # Extended-request students get at least the standard window; a course

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,9 +34,9 @@ class User < ApplicationRecord
   # Relationship with Extension
   has_many :extensions
 
-  # Relationship with Course (and UserToCourse)
-  has_many :user_to_courses
-  has_many :courses, through: :user_to_courses
+  # Relationship with Course (and Enrollment)
+  has_many :enrollments
+  has_many :courses, through: :enrollments
 
   # TODO: We should probably use lms_id over lms_name
   def canvas_credentials

--- a/app/views/courses/enrollments.html.erb
+++ b/app/views/courses/enrollments.html.erb
@@ -65,7 +65,7 @@
                             data-enrollments-target="checkbox"
                             data-action="change->enrollments#toggleExtended"
                             data-enrollment-id="<%= enrollment.id %>"
-                            data-url="<%= toggle_allow_extended_requests_course_user_to_course_path(@course, enrollment) %>">
+                            data-url="<%= toggle_allow_extended_requests_course_enrollment_path(@course, enrollment) %>">
                       <label class="visually-hidden" for="extended-<%= enrollment.id %>-enabled">
                         Approve extended requests for <%= enrollment.user.name %>
                       </label>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -25,15 +25,15 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <% @teacher_courses_by_semester.each do |semester, user_to_courses| %>
+                    <% @teacher_courses_by_semester.each do |semester, enrollments| %>
                         <tr class="table-blue-light">
                             <td colspan="3" class="fw-bold"><%= semester || "Unknown Semester" %></td>
                         </tr>
-                        <% user_to_courses.each do |user_to_course| %>
+                        <% enrollments.each do |enrollment| %>
                             <tr>
-                                <td><a href="/courses/<%= user_to_course.course.id %>"> <%= user_to_course.course.course_name %> </a></td>
-                                <td><%= user_to_course.course.course_code %></td>
-                                <td><%= user_to_course.display_role %></td>
+                                <td><a href="/courses/<%= enrollment.course.id %>"> <%= enrollment.course.course_name %> </a></td>
+                                <td><%= enrollment.course.course_code %></td>
+                                <td><%= enrollment.display_role %></td>
                             </tr>
                         <% end %>
                     <% end %>
@@ -61,14 +61,14 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <% @student_courses_by_semester.each do |semester, user_to_courses| %>
+                    <% @student_courses_by_semester.each do |semester, enrollments| %>
                         <tr class="table-blue-light">
                             <td colspan="2" class="fw-bold"><%= semester || "Unknown Semester" %></td>
                         </tr>
-                        <% user_to_courses.each do |user_to_course| %>
+                        <% enrollments.each do |enrollment| %>
                             <tr>
-                                <td><a href="/courses/<%= user_to_course.course.id %>"> <%= user_to_course.course.course_name %></a></td>
-                                <td><%= user_to_course.course.course_code %></td>
+                                <td><a href="/courses/<%= enrollment.course.id %>"> <%= enrollment.course.course_name %></a></td>
+                                <td><%= enrollment.course.course_code %></td>
                             </tr>
                         <% end %>
                     <% end %>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -47,8 +47,8 @@
                 <td><%= course["course_code"] %></td>
                 <td><%= course["name"] %></td>
                 <td>
-                  <% staff_enrollment = course['enrollments'].find { |enrollment| UserToCourse.staff_enrollment?(enrollment) } %>
-                  <%= UserToCourse.display_role(UserToCourse.role_from_canvas_enrollment(staff_enrollment)) %>
+                  <% staff_enrollment = course['enrollments'].find { |enrollment| Enrollment.staff_enrollment?(enrollment) } %>
+                  <%= Enrollment.display_role(Enrollment.role_from_canvas_enrollment(staff_enrollment)) %>
                 </td>
               </tr>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
         get :export, defaults: { format: :csv }
       end
     end
-    resources :user_to_courses, only: [] do
+    resources :enrollments, only: [] do
       member do
         patch :toggle_allow_extended_requests
       end

--- a/db/api_spec_seeds.rb
+++ b/db/api_spec_seeds.rb
@@ -6,7 +6,7 @@ LmsCredential.destroy_all
 Extension.destroy_all
 Assignment.destroy_all
 CourseToLms.destroy_all
-UserToCourse.destroy_all
+Enrollment.destroy_all
 Course.destroy_all
 User.destroy_all
 
@@ -33,7 +33,7 @@ test_user = User.create!({
   email: "testuser@example.com",
 })
 
-test_user_to_course = UserToCourse.create!({
+test_enrollment = Enrollment.create!({
   user_id: test_user.id,
   course_id: test_course.id,
   role: "test",

--- a/db/migrate/20260704000001_rename_user_to_courses_to_enrollments.rb
+++ b/db/migrate/20260704000001_rename_user_to_courses_to_enrollments.rb
@@ -1,0 +1,5 @@
+class RenameUserToCoursesToEnrollments < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { rename_table :user_to_courses, :enrollments }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_03_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_04_000001) do
   create_schema "hypershield"
 
   # These are extensions that must be enabled in order to support this database
@@ -136,6 +136,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_03_000001) do
     t.index ["readonly_api_token"], name: "index_courses_on_readonly_api_token", unique: true
   end
 
+  create_table "enrollments", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "course_id"
+    t.string "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "removed", default: false, null: false
+    t.boolean "allow_extended_requests", default: false, null: false
+    t.index ["course_id"], name: "index_enrollments_on_course_id"
+    t.index ["user_id"], name: "index_enrollments_on_user_id"
+  end
+
   create_table "extensions", force: :cascade do |t|
     t.bigint "assignment_id"
     t.string "student_email"
@@ -209,18 +221,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_03_000001) do
     t.index ["user_id"], name: "index_requests_on_user_id"
   end
 
-  create_table "user_to_courses", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "course_id"
-    t.string "role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "removed", default: false, null: false
-    t.boolean "allow_extended_requests", default: false, null: false
-    t.index ["course_id"], name: "index_user_to_courses_on_course_id"
-    t.index ["user_id"], name: "index_user_to_courses_on_user_id"
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.datetime "created_at", null: false
@@ -238,6 +238,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_03_000001) do
   add_foreign_key "course_settings", "courses"
   add_foreign_key "course_to_lmss", "courses"
   add_foreign_key "course_to_lmss", "lmss"
+  add_foreign_key "enrollments", "courses"
+  add_foreign_key "enrollments", "users"
   add_foreign_key "extensions", "assignments"
   add_foreign_key "extensions", "users", column: "last_processed_by_id"
   add_foreign_key "form_settings", "courses"
@@ -246,6 +248,4 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_03_000001) do
   add_foreign_key "requests", "courses"
   add_foreign_key "requests", "users"
   add_foreign_key "requests", "users", column: "last_processed_by_user_id"
-  add_foreign_key "user_to_courses", "courses"
-  add_foreign_key "user_to_courses", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,13 +40,13 @@ if Rails.env.development?
   end
 
   # Enroll teacher as instructor
-  UserToCourse.find_or_create_by!(user_id: teacher_user.id, course_id: test_course.id) do |utc|
-    utc.role = 'teacher'
+  Enrollment.find_or_create_by!(user_id: teacher_user.id, course_id: test_course.id) do |enrollment|
+    enrollment.role = 'teacher'
   end
 
   # Enroll student as student
-  UserToCourse.find_or_create_by!(user_id: student_user.id, course_id: test_course.id) do |utc|
-    utc.role = 'student'
+  Enrollment.find_or_create_by!(user_id: student_user.id, course_id: test_course.id) do |enrollment|
+    enrollment.role = 'student'
   end
 
   # Enable extensions for test course (settings are created with the course)

--- a/features/step_definitions/custom_steps.rb
+++ b/features/step_definitions/custom_steps.rb
@@ -3,14 +3,14 @@ Given(/^a course exists$/) do
   @course = create(:course, course_name: 'Physics 110A', canvas_id: 'Phys110A', course_code: 'PHYS110A')
 
   teacher = create(:teacher, email: 'user1@berkeley.edu', canvas_uid: 'canvas_uid_1')
-  create(:user_to_course, user: teacher, course: @course, role: 'teacher')
+  create(:enrollment, user: teacher, course: @course, role: 'teacher')
 
   ta = create(:ta, email: 'user2@berkeley.edu', canvas_uid: 'canvas_uid_2')
-  create(:user_to_course, user: ta, course: @course, role: 'ta')
+  create(:enrollment, user: ta, course: @course, role: 'ta')
 
   3.times do |i|
     student = create(:student, email: "user#{i + 3}@berkeley.edu", canvas_uid: "canvas_uid_#{i + 3}")
-    create(:user_to_course, user: student, course: @course, role: 'student')
+    create(:enrollment, user: student, course: @course, role: 'student')
   end
 end
 
@@ -133,7 +133,7 @@ end
 # Then the enrollment for "User 3" should allow/disallow extended requests
 Then(/^the enrollment for "([^"]*)" should (allow|disallow) extended requests$/) do |user_name, state|
   user = User.find_by!(name: user_name)
-  enrollment = UserToCourse.find_by!(user: user, course: @course, role: 'student')
+  enrollment = Enrollment.find_by!(user: user, course: @course, role: 'student')
   expected = (state == 'allow')
   expect(enrollment.reload.allow_extended_requests).to eq(expected)
 end
@@ -142,7 +142,7 @@ end
 # Given the enrollment for "User 3" allows extended requests
 Given(/^the enrollment for "([^"]*)" allows extended requests$/) do |user_name|
   user = User.find_by!(name: user_name)
-  enrollment = UserToCourse.find_by!(user: user, course: @course, role: 'student')
+  enrollment = Enrollment.find_by!(user: user, course: @course, role: 'student')
   enrollment.update!(allow_extended_requests: true)
 end
 
@@ -196,7 +196,7 @@ Then(/^the requests table search should be filtered$/) do
 end
 
 Given(/^a pending request exists$/) do
-  student = User.joins(:user_to_courses).find_by(user_to_courses: { course: @course, role: 'student' })
+  student = User.joins(:enrollments).find_by(enrollments: { course: @course, role: 'student' })
   assignment = Assignment.first
   @pending_request = create(:request, user: student, course: @course, assignment: assignment)
 end

--- a/spec/controllers/api/v1/assignments_controller_spec.rb
+++ b/spec/controllers/api/v1/assignments_controller_spec.rb
@@ -24,7 +24,7 @@ module API
         Extension.destroy_all
         Assignment.destroy_all
         CourseToLms.destroy_all
-        UserToCourse.destroy_all
+        Enrollment.destroy_all
         Course.destroy_all
         Lms.destroy_all
         User.destroy_all

--- a/spec/controllers/api/v1/lmss_controller_spec.rb
+++ b/spec/controllers/api/v1/lmss_controller_spec.rb
@@ -18,7 +18,7 @@ module API
         Extension.destroy_all
         Assignment.destroy_all
         CourseToLms.destroy_all
-        UserToCourse.destroy_all
+        Enrollment.destroy_all
         Course.destroy_all
         Lms.destroy_all
         User.destroy_all

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AssignmentsController, type: :controller do
 
     context 'when the user is an instructor' do
       before do
-        UserToCourse.create!(user: user, course: course, role: UserToCourse::TEACHER_ROLE)
+        Enrollment.create!(user: user, course: course, role: Enrollment::TEACHER_ROLE)
       end
 
       it 'updates the enabled status to true' do
@@ -45,7 +45,7 @@ RSpec.describe AssignmentsController, type: :controller do
 
     context 'when the user is not an instructor' do
       before do
-        UserToCourse.create!(user: user, course: course, role: UserToCourse::STUDENT_ROLE)
+        Enrollment.create!(user: user, course: course, role: Enrollment::STUDENT_ROLE)
       end
 
       it 'returns a forbidden status' do
@@ -58,7 +58,7 @@ RSpec.describe AssignmentsController, type: :controller do
 
     context 'when a student forges an instructor role in the request body' do
       before do
-        UserToCourse.create!(user: user, course: course, role: UserToCourse::STUDENT_ROLE)
+        Enrollment.create!(user: user, course: course, role: Enrollment::STUDENT_ROLE)
       end
 
       it 'ignores the client-supplied role and returns forbidden' do
@@ -72,7 +72,7 @@ RSpec.describe AssignmentsController, type: :controller do
     context 'when course-level extensions are disabled' do
       before do
         course_settings.update!(enable_extensions: false)
-        UserToCourse.create!(user: user, course: course, role: UserToCourse::TEACHER_ROLE)
+        Enrollment.create!(user: user, course: course, role: Enrollment::TEACHER_ROLE)
       end
 
       it 'still allows enabling the assignment and returns ok status' do
@@ -85,7 +85,7 @@ RSpec.describe AssignmentsController, type: :controller do
 
     context 'when there is no due_date on an Assignment' do
       before do
-        UserToCourse.create!(user: user, course: course, role: UserToCourse::TEACHER_ROLE)
+        Enrollment.create!(user: user, course: course, role: Enrollment::TEACHER_ROLE)
         assignment.update!(due_date: nil)
       end
 

--- a/spec/controllers/course_settings_controller_spec.rb
+++ b/spec/controllers/course_settings_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CourseSettingsController, type: :controller do
   describe 'instructor access' do
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
+      Enrollment.create!(user: instructor, course: course, role: 'instructor')
       allow_any_instance_of(Course).to receive(:user_role).with(instructor).and_return('instructor')
     end
 
@@ -128,7 +128,7 @@ RSpec.describe CourseSettingsController, type: :controller do
 
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
+      Enrollment.create!(user: instructor, course: course, role: 'instructor')
       allow_any_instance_of(Course).to receive(:user_role).with(instructor).and_return('instructor')
 
       # Enable extensions on the course's settings
@@ -186,7 +186,7 @@ RSpec.describe CourseSettingsController, type: :controller do
         refresh_token: 'student_refresh_token',
         expire_time: 1.hour.from_now
       )
-      UserToCourse.create!(user: student, course: course, role: 'student')
+      Enrollment.create!(user: student, course: course, role: 'student')
       allow_any_instance_of(Course).to receive(:user_role).with(student).and_return('student')
 
       # Configure course settings to attempt to modify
@@ -242,7 +242,7 @@ RSpec.describe CourseSettingsController, type: :controller do
 
     it 'redirects to courses path when course is not found' do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'instructor')
+      Enrollment.create!(user: instructor, course: course, role: 'instructor')
 
       post :update, params: {
         course_id: 999,

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CoursesController, type: :controller do
 
   before do
     session[:user_id] = user.canvas_uid
-    UserToCourse.create!(user: user, course: course, role: 'student')
+    Enrollment.create!(user: user, course: course, role: 'student')
     user.lms_credentials.create!(
       lms_name: 'canvas',
       token: 'fake_token',
@@ -30,7 +30,7 @@ RSpec.describe CoursesController, type: :controller do
     end
 
     it 'includes Lead TA enrollments in staff courses' do
-      UserToCourse.create!(user: user, course: student_course, role: 'leadta')
+      Enrollment.create!(user: user, course: student_course, role: 'leadta')
 
       get :index
 
@@ -42,8 +42,8 @@ RSpec.describe CoursesController, type: :controller do
       let(:fall_course) { Course.create!(course_name: 'Fall Course', canvas_id: 'fa1', course_code: 'FA101', semester: 'Fall 2025') }
 
       before do
-        UserToCourse.create!(user: user, course: spring_course, role: 'teacher')
-        UserToCourse.create!(user: user, course: fall_course, role: 'teacher')
+        Enrollment.create!(user: user, course: spring_course, role: 'teacher')
+        Enrollment.create!(user: user, course: fall_course, role: 'teacher')
       end
 
       it 'groups teacher courses by semester, most-recent-first' do
@@ -60,8 +60,8 @@ RSpec.describe CoursesController, type: :controller do
         fall_student = Course.create!(course_name: 'Student Fall', canvas_id: 'sf1', course_code: 'SF101', semester: 'Fall 2025')
         spring_student.course_settings.update!(enable_extensions: true)
         fall_student.course_settings.update!(enable_extensions: true)
-        UserToCourse.create!(user: user, course: spring_student, role: 'student')
-        UserToCourse.create!(user: user, course: fall_student, role: 'student')
+        Enrollment.create!(user: user, course: spring_student, role: 'student')
+        Enrollment.create!(user: user, course: fall_student, role: 'student')
 
         get :index
 
@@ -94,7 +94,7 @@ RSpec.describe CoursesController, type: :controller do
       let!(:course_to_lms_record) { CourseToLms.create!(course: course, external_course_id: '456', lms_id: 1) }
 
       before do
-        UserToCourse.create!(user: user, course: course, role: 'teacher')
+        Enrollment.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'renders the instructor show template' do
@@ -199,7 +199,7 @@ RSpec.describe CoursesController, type: :controller do
 
     context 'when user is a teacher (course admin)' do
       before do
-        UserToCourse.create!(user: user, course: course, role: 'teacher')
+        Enrollment.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'syncs enrollments and returns OK' do
@@ -214,7 +214,7 @@ RSpec.describe CoursesController, type: :controller do
 
     context 'when user is a leadta (course admin)' do
       before do
-        UserToCourse.create!(user: user, course: course, role: 'leadta')
+        Enrollment.create!(user: user, course: course, role: 'leadta')
       end
 
       it 'syncs enrollments and returns OK' do
@@ -229,7 +229,7 @@ RSpec.describe CoursesController, type: :controller do
 
     context 'when user is a TA (staff but not course admin)' do
       before do
-        UserToCourse.create!(user: user, course: course, role: 'ta')
+        Enrollment.create!(user: user, course: course, role: 'ta')
       end
 
       it 'syncs enrollments and returns OK' do
@@ -396,7 +396,7 @@ RSpec.describe CoursesController, type: :controller do
 
     context 'when user is a teacher (course admin)' do
       before do
-        UserToCourse.create!(user: user, course: course, role: 'teacher')
+        Enrollment.create!(user: user, course: course, role: 'teacher')
       end
 
       it 'renders the enrollments view successfully' do
@@ -419,7 +419,7 @@ RSpec.describe CoursesController, type: :controller do
 
     context 'when user is a TA (staff but not course admin)' do
       before do
-        UserToCourse.create!(user: user, course: course, role: 'ta')
+        Enrollment.create!(user: user, course: course, role: 'ta')
       end
 
       it 'renders the enrollments view successfully' do
@@ -456,7 +456,7 @@ RSpec.describe CoursesController, type: :controller do
 
     before do
       Extension.create!(assignment: assignment, student_email: user.email)
-      UserToCourse.create!(user: user, course: course, role: 'teacher')
+      Enrollment.create!(user: user, course: course, role: 'teacher')
       Request.create!(course: course, assignment: assignment, user: user, requested_due_date: Time.current, reason: 'Reason')
       FormSetting.create!(
         course: course,
@@ -473,7 +473,7 @@ RSpec.describe CoursesController, type: :controller do
                                    .and change(Assignment, :count).by(-1)
                                                                   .and change(Extension, :count).by(-1)
                                                                                                 .and change(CourseToLms, :count).by(-1)
-                                                                                                                                .and change(UserToCourse, :count).by(-2)
+                                                                                                                                .and change(Enrollment, :count).by(-2)
                                                                                                                                                                  .and change(Request, :count).by(-1)
                                                                                                                                                                                              .and change(CourseSettings, :count).by(-1)
                                                                                                                                                                                                                                 .and change(FormSetting,

--- a/spec/controllers/enrollments_controller_spec.rb
+++ b/spec/controllers/enrollments_controller_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe UserToCoursesController, type: :controller do
+RSpec.describe EnrollmentsController, type: :controller do
   let(:instructor) { User.create!(email: 'instructor@example.com', canvas_uid: '100', name: 'Instructor') }
   let(:student_user) { User.create!(email: 'student@example.com', canvas_uid: '200', name: 'Student') }
   let(:course) { Course.create!(course_name: 'Test Course', canvas_id: '456', course_code: 'TST101') }
-  let(:student_enrollment) { UserToCourse.create!(user: student_user, course: course, role: 'student') }
+  let(:student_enrollment) { Enrollment.create!(user: student_user, course: course, role: 'student') }
 
   describe 'PATCH #toggle_allow_extended_requests' do
     context 'when user is an instructor' do
       before do
-        UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+        Enrollment.create!(user: instructor, course: course, role: 'teacher')
         student_enrollment
         session[:user_id] = instructor.canvas_uid
         instructor.lms_credentials.create!(
@@ -49,8 +49,8 @@ RSpec.describe UserToCoursesController, type: :controller do
       it 'returns unprocessable_entity when update fails' do
         errors = ActiveModel::Errors.new(student_enrollment)
         errors.add(:base, 'Validation failed')
-        allow_any_instance_of(UserToCourse).to receive(:update).and_return(false)
-        allow_any_instance_of(UserToCourse).to receive(:errors).and_return(errors)
+        allow_any_instance_of(Enrollment).to receive(:update).and_return(false)
+        allow_any_instance_of(Enrollment).to receive(:errors).and_return(errors)
 
         patch :toggle_allow_extended_requests, params: {
           course_id: course.id,
@@ -123,7 +123,7 @@ RSpec.describe UserToCoursesController, type: :controller do
 
     context 'when enrollment does not exist' do
       before do
-        UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+        Enrollment.create!(user: instructor, course: course, role: 'teacher')
         session[:user_id] = instructor.canvas_uid
         instructor.lms_credentials.create!(
           lms_name: 'canvas',

--- a/spec/controllers/form_settings_controller_spec.rb
+++ b/spec/controllers/form_settings_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FormSettingsController, type: :controller do
   let(:user) { User.create!(email: 'instructor@example.com', canvas_uid: '12345', name: 'Instructor') }
   let(:course) { Course.create!(course_name: 'Algorithms', canvas_id: '789', course_code: 'CS101') }
-  let(:user_to_course) { UserToCourse.create!(user: user, course: course, role: 'teacher') }
+  let(:enrollment) { Enrollment.create!(user: user, course: course, role: 'teacher') }
   let(:valid_params) do
     {
       course_id: course.id,

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RequestsController, type: :controller do
       custom_q1_disp: 'hidden',
       custom_q2_disp: 'hidden'
     )
-    UserToCourse.create!(user: user, course: course, role: 'student')
+    Enrollment.create!(user: user, course: course, role: 'student')
     CourseToLms.create!(course:, lms_id: 1)
 
     user.lms_credentials.create!(
@@ -44,7 +44,7 @@ RSpec.describe RequestsController, type: :controller do
 
     it 'renders instructor request index' do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: teacher_course, role: 'teacher') # or use 'ta'
+      Enrollment.create!(user: instructor, course: teacher_course, role: 'teacher') # or use 'ta'
       FormSetting.create!(course: teacher_course, documentation_disp: 'hidden', custom_q1_disp: 'hidden', custom_q2_disp: 'hidden')
       get :index, params: { course_id: teacher_course.id }
 
@@ -54,7 +54,7 @@ RSpec.describe RequestsController, type: :controller do
 
     it 'assigns @search_query from params[:search]' do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: teacher_course, role: 'teacher')
+      Enrollment.create!(user: instructor, course: teacher_course, role: 'teacher')
       FormSetting.create!(course: teacher_course, documentation_disp: 'hidden', custom_q1_disp: 'hidden', custom_q2_disp: 'hidden')
 
       get :index, params: { course_id: teacher_course.id, search: '12345', show_all: 'true' }
@@ -64,7 +64,7 @@ RSpec.describe RequestsController, type: :controller do
 
     it 'assigns @search_query as nil when no search param is provided' do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: teacher_course, role: 'teacher')
+      Enrollment.create!(user: instructor, course: teacher_course, role: 'teacher')
       FormSetting.create!(course: teacher_course, documentation_disp: 'hidden', custom_q1_disp: 'hidden', custom_q2_disp: 'hidden')
 
       get :index, params: { course_id: teacher_course.id }
@@ -297,7 +297,7 @@ RSpec.describe RequestsController, type: :controller do
   describe 'POST #cancel' do
     before do
       session[:user_id] = user.canvas_uid
-      UserToCourse.create!(user: user, course: course, role: 'student')
+      Enrollment.create!(user: user, course: course, role: 'student')
     end
 
     it 'cancels the request and updates its status to denied' do
@@ -329,7 +329,7 @@ RSpec.describe RequestsController, type: :controller do
   describe 'POST #approve' do
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+      Enrollment.create!(user: instructor, course: course, role: 'teacher')
       instructor.lms_credentials.create!(
         lms_name: 'canvas',
         token: 'instructor_token',
@@ -401,7 +401,7 @@ RSpec.describe RequestsController, type: :controller do
   describe 'POST #reject' do
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+      Enrollment.create!(user: instructor, course: course, role: 'teacher')
       FormSetting.create!(course: course, documentation_disp: 'hidden', custom_q1_disp: 'hidden', custom_q2_disp: 'hidden')
     end
 
@@ -465,7 +465,7 @@ RSpec.describe RequestsController, type: :controller do
 
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+      Enrollment.create!(user: instructor, course: course, role: 'teacher')
       instructor.lms_credentials.create!(
         lms_name: 'canvas',
         token: 'instructor_token',
@@ -531,7 +531,7 @@ RSpec.describe RequestsController, type: :controller do
 
     before do
       session[:user_id] = instructor.canvas_uid
-      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+      Enrollment.create!(user: instructor, course: course, role: 'teacher')
     end
 
     it 'rejects selected requests and returns processed IDs' do
@@ -572,7 +572,7 @@ RSpec.describe RequestsController, type: :controller do
 
     before do
       session[:user_id] = user.canvas_uid
-      UserToCourse.create!(user: user, course: course, role: 'student')
+      Enrollment.create!(user: user, course: course, role: 'student')
 
       # Configure course settings for auto-approval
       course.course_settings.update!(
@@ -674,7 +674,7 @@ RSpec.describe RequestsController, type: :controller do
 
     before do
       session[:user_id] = user.canvas_uid
-      UserToCourse.create!(user: user, course: course, role: 'student')
+      Enrollment.create!(user: user, course: course, role: 'student')
 
       # Configure course settings for auto-approval
       course.course_settings.update!(
@@ -811,7 +811,7 @@ RSpec.describe RequestsController, type: :controller do
         Request.create!(user: other_student, course: course, assignment: assignment, reason: 'Theirs', requested_due_date: 3.days.from_now)
       end
 
-      before { UserToCourse.create!(user: other_student, course: course, role: 'student') }
+      before { Enrollment.create!(user: other_student, course: course, role: 'student') }
 
       it 'is not viewable via #show' do
         get :show, params: { course_id: course.id, id: others_request.id }
@@ -847,7 +847,7 @@ RSpec.describe RequestsController, type: :controller do
 
       before do
         session[:user_id] = instructor.canvas_uid
-        UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+        Enrollment.create!(user: instructor, course: course, role: 'teacher')
       end
 
       it 'rejects filing on behalf of a student who is not enrolled in the course' do
@@ -884,7 +884,7 @@ RSpec.describe RequestsController, type: :controller do
       end
 
       it 'creates a request for an enrolled student' do
-        UserToCourse.create!(user: enrolled_student, course: course, role: 'student')
+        Enrollment.create!(user: enrolled_student, course: course, role: 'student')
 
         post :create_for_student, params: {
           course_id: course.id,
@@ -901,7 +901,7 @@ RSpec.describe RequestsController, type: :controller do
       end
 
       it 'treats an assignment from another course as an invalid request' do
-        UserToCourse.create!(user: enrolled_student, course: course, role: 'student')
+        Enrollment.create!(user: enrolled_student, course: course, role: 'student')
 
         post :create_for_student, params: {
           course_id: course.id,

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe SessionController, type: :controller do
         get :omniauth_callback, params: { provider: 'developer' }
 
         user = User.find_by(canvas_uid: 'test@example.com')
-        enrollment = UserToCourse.find_by(user_id: user.id, course_id: test_course.id)
+        enrollment = Enrollment.find_by(user_id: user.id, course_id: test_course.id)
 
         expect(enrollment).to be_present
         expect(enrollment.role).to eq('student')

--- a/spec/factories/enrollment.rb
+++ b/spec/factories/enrollment.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :user_to_course do
+  factory :enrollment do
     association :user
     association :course
     role { 'student' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
 
     after(:create) do |user, evaluator|
       evaluator.courses.each do |course|
-        create(:user_to_course, user: user, course: course, role: evaluator.role)
+        create(:enrollment, user: user, course: course, role: evaluator.role)
       end
     end
 
@@ -48,15 +48,15 @@ FactoryBot.define do
     end
 
     factory :teacher do
-      after(:create) { |user| create(:user_to_course, user: user, role: 'teacher') }
+      after(:create) { |user| create(:enrollment, user: user, role: 'teacher') }
     end
 
     factory :ta do
-      after(:create) { |user| create(:user_to_course, user: user, role: 'ta') }
+      after(:create) { |user| create(:enrollment, user: user, role: 'ta') }
     end
 
     factory :student do
-      after(:create) { |user| create(:user_to_course, user: user, role: 'student') }
+      after(:create) { |user| create(:enrollment, user: user, role: 'student') }
     end
   end
 end

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -41,18 +41,18 @@ RSpec.describe 'Accessibility', :a11y, :js, type: :feature do
   let!(:c3_assignment4) { create(:assignment, name: 'CS Project 2', course_to_lms: course_to_lms3, external_assignment_id: 'cs_p2', due_date: 30.days.from_now, late_due_date: 32.days.from_now) }
   let!(:c3_assignment5) { create(:assignment, name: 'CS Final', course_to_lms: course_to_lms3, external_assignment_id: 'cs_final', due_date: 37.days.from_now, late_due_date: 37.days.from_now) }
 
-  let!(:teacher1_course1) { create(:user_to_course, user: teacher1, course: course1, role: 'teacher') }
-  let!(:teacher1_course2) { create(:user_to_course, user: teacher1, course: course2, role: 'teacher') }
-  let!(:teacher2_course3) { create(:user_to_course, user: teacher2, course: course3, role: 'teacher') }
+  let!(:teacher1_course1) { create(:enrollment, user: teacher1, course: course1, role: 'teacher') }
+  let!(:teacher1_course2) { create(:enrollment, user: teacher1, course: course2, role: 'teacher') }
+  let!(:teacher2_course3) { create(:enrollment, user: teacher2, course: course3, role: 'teacher') }
 
-  let!(:student1_course1) { create(:user_to_course, user: student1, course: course1, role: 'student') }
-  let!(:student1_course2) { create(:user_to_course, user: student1, course: course2, role: 'student') }
-  let!(:student2_course1) { create(:user_to_course, user: student2, course: course1, role: 'student') }
-  let!(:student2_course3) { create(:user_to_course, user: student2, course: course3, role: 'student') }
-  let!(:student3_course2) { create(:user_to_course, user: student3, course: course2, role: 'student') }
-  let!(:student3_course3) { create(:user_to_course, user: student3, course: course3, role: 'student') }
-  let!(:student4_course1) { create(:user_to_course, user: student4, course: course1, role: 'student') }
-  let!(:student4_course3) { create(:user_to_course, user: student4, course: course3, role: 'student') }
+  let!(:student1_course1) { create(:enrollment, user: student1, course: course1, role: 'student') }
+  let!(:student1_course2) { create(:enrollment, user: student1, course: course2, role: 'student') }
+  let!(:student2_course1) { create(:enrollment, user: student2, course: course1, role: 'student') }
+  let!(:student2_course3) { create(:enrollment, user: student2, course: course3, role: 'student') }
+  let!(:student3_course2) { create(:enrollment, user: student3, course: course2, role: 'student') }
+  let!(:student3_course3) { create(:enrollment, user: student3, course: course3, role: 'student') }
+  let!(:student4_course1) { create(:enrollment, user: student4, course: course1, role: 'student') }
+  let!(:student4_course3) { create(:enrollment, user: student4, course: course3, role: 'student') }
 
   let!(:c1_request1) { create(:request, :approved, course: course1, user: student1, assignment: c1_assignment1, reason: 'Medical emergency', requested_due_date: 12.days.from_now) }
   let!(:c1_request2) { create(:request, course: course1, user: student2, assignment: c1_assignment2, reason: 'Family emergency', requested_due_date: 18.days.from_now) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Course, type: :model do
         refresh_token: 'refresh_token',
         expire_time: 1.hour.from_now
       )
-      UserToCourse.create!(user: user, course: course, role: 'ta')
+      Enrollment.create!(user: user, course: course, role: 'ta')
 
       staff_user = course.staff_user_for_auto_approval
       expect(staff_user).to eq(user)
@@ -103,7 +103,7 @@ RSpec.describe Course, type: :model do
     it 'skips staff users without Canvas credentials' do
       course = described_class.create!(canvas_id: 'canvas_124', course_name: 'Test', course_code: 'TEST101')
       synced_ta = User.create!(email: 'synced_ta@example.com', canvas_uid: '124')
-      UserToCourse.create!(user: synced_ta, course: course, role: 'ta')
+      Enrollment.create!(user: synced_ta, course: course, role: 'ta')
 
       instructor = User.create!(email: 'instructor2@example.com', canvas_uid: '125')
       instructor.lms_credentials.create!(
@@ -112,7 +112,7 @@ RSpec.describe Course, type: :model do
         refresh_token: 'refresh_token',
         expire_time: 1.hour.from_now
       )
-      UserToCourse.create!(user: instructor, course: course, role: 'teacher')
+      Enrollment.create!(user: instructor, course: course, role: 'teacher')
 
       expect(course.staff_user_for_auto_approval).to eq(instructor)
     end
@@ -120,7 +120,7 @@ RSpec.describe Course, type: :model do
     it 'returns nil when no staff user has Canvas credentials' do
       course = described_class.create!(canvas_id: 'canvas_125', course_name: 'Test', course_code: 'TEST101')
       synced_ta = User.create!(email: 'synced_ta2@example.com', canvas_uid: '126')
-      UserToCourse.create!(user: synced_ta, course: course, role: 'ta')
+      Enrollment.create!(user: synced_ta, course: course, role: 'ta')
 
       expect(course.staff_user_for_auto_approval).to be_nil
     end
@@ -133,14 +133,14 @@ RSpec.describe Course, type: :model do
         lms_name: 'canvas', token: 'stale', refresh_token: 'stale',
         expire_time: 6.months.ago, updated_at: 6.months.ago
       )
-      UserToCourse.create!(user: idle_ta, course: course, role: 'ta')
+      Enrollment.create!(user: idle_ta, course: course, role: 'ta')
 
       active_teacher = User.create!(email: 'active_teacher@example.com', canvas_uid: '128')
       active_teacher.lms_credentials.create!(
         lms_name: 'canvas', token: 'fresh', refresh_token: 'fresh',
         expire_time: 1.hour.from_now
       )
-      UserToCourse.create!(user: active_teacher, course: course, role: 'teacher')
+      Enrollment.create!(user: active_teacher, course: course, role: 'teacher')
 
       expect(course.staff_users_for_auto_approval).to eq([ active_teacher, idle_ta ])
     end
@@ -150,7 +150,7 @@ RSpec.describe Course, type: :model do
     it 'treats leadta enrollments as instructors' do
       course = described_class.create!(canvas_id: 'canvas_leadta', course_name: 'Test', course_code: 'TEST101')
       user = User.create!(email: 'leadta@example.com', canvas_uid: 'leadta_123')
-      UserToCourse.create!(user: user, course: course, role: 'leadta')
+      Enrollment.create!(user: user, course: course, role: 'leadta')
 
       expect(course.user_role(user)).to eq('instructor')
     end
@@ -300,11 +300,11 @@ end
       allow(user).to receive(:ensure_fresh_canvas_token!).and_return('fake_token')
     end
 
-    it 'creates user and user_to_course record' do
+    it 'creates user and enrollment record' do
       expect do
         course.sync_users_from_canvas(user.id, 'student')
       end.to change(User, :count).by(CANVAS_USERS.size).and(
-        change(UserToCourse, :count).by(CANVAS_USERS.size)
+        change(Enrollment, :count).by(CANVAS_USERS.size)
       )
     end
   end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: user_to_courses
+# Table name: enrollments
 #
 #  id                      :bigint           not null, primary key
 #  allow_extended_requests :boolean          default(FALSE), not null
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_user_to_courses_on_course_id  (course_id)
-#  index_user_to_courses_on_user_id    (user_id)
+#  index_enrollments_on_course_id  (course_id)
+#  index_enrollments_on_user_id    (user_id)
 #
 # Foreign Keys
 #
@@ -23,20 +23,20 @@
 #
 require 'rails_helper'
 
-RSpec.describe UserToCourse, type: :model do
+RSpec.describe Enrollment, type: :model do
   describe 'Lead TA role support' do
     it 'treats leadta as a supported staff role' do
-      user_to_course = build(:user_to_course, role: 'leadta')
+      enrollment = build(:enrollment, role: 'leadta')
 
       expect(described_class.staff_roles).to include('leadta')
       expect(described_class.roles).to include('leadta')
-      expect(user_to_course).to be_staff
+      expect(enrollment).to be_staff
     end
 
     it 'treats leadta as a course admin role' do
-      user_to_course = build(:user_to_course, role: 'leadta')
+      enrollment = build(:enrollment, role: 'leadta')
 
-      expect(user_to_course).to be_course_admin
+      expect(enrollment).to be_course_admin
     end
   end
 
@@ -56,9 +56,9 @@ RSpec.describe UserToCourse, type: :model do
 
   describe '#display_role' do
     it 'formats leadta as Lead TA' do
-      user_to_course = build(:user_to_course, role: 'leadta')
+      enrollment = build(:enrollment, role: 'leadta')
 
-      expect(user_to_course.display_role).to eq('Lead TA')
+      expect(enrollment.display_role).to eq('Lead TA')
     end
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Request, type: :model do
   end
 
   before do
-    UserToCourse.create!(user: user, course: course, role: 'student')
+    Enrollment.create!(user: user, course: course, role: 'student')
     user.lms_credentials.create!(
       lms_name: 'canvas',
       token: 'fake_token',
@@ -323,7 +323,7 @@ RSpec.describe Request, type: :model do
     context 'when student has allow_extended_requests and requests more than auto_approve_days' do
       before do
         course_settings.update(auto_approve_days: 3, auto_approve_extended_request_days: 7)
-        UserToCourse.find_by(user: user, course: course).update!(allow_extended_requests: true)
+        Enrollment.find_by(user: user, course: course).update!(allow_extended_requests: true)
       end
 
       it 'returns true when within extended request days' do
@@ -340,7 +340,7 @@ RSpec.describe Request, type: :model do
     context 'when student has allow_extended_requests but extended days are disabled (0)' do
       before do
         course_settings.update(auto_approve_days: 2, auto_approve_extended_request_days: 0)
-        UserToCourse.find_by(user: user, course: course).update!(allow_extended_requests: true)
+        Enrollment.find_by(user: user, course: course).update!(allow_extended_requests: true)
       end
 
       it 'falls back to the standard auto_approve_days window' do
@@ -357,7 +357,7 @@ RSpec.describe Request, type: :model do
     context 'when student does not have allow_extended_requests' do
       before do
         course_settings.update(auto_approve_days: 3, auto_approve_extended_request_days: 7)
-        UserToCourse.find_by(user: user, course: course).update!(allow_extended_requests: false)
+        Enrollment.find_by(user: user, course: course).update!(allow_extended_requests: false)
       end
 
       it 'returns false when exceeding standard auto_approve_days' do
@@ -374,7 +374,7 @@ RSpec.describe Request, type: :model do
     context 'when student requests exactly the max extended days' do
       before do
         course_settings.update(auto_approve_days: 3, auto_approve_extended_request_days: 7)
-        UserToCourse.find_by(user: user, course: course).update!(allow_extended_requests: true)
+        Enrollment.find_by(user: user, course: course).update!(allow_extended_requests: true)
       end
 
       it 'returns true at the boundary' do
@@ -396,7 +396,7 @@ RSpec.describe Request, type: :model do
     context 'when user has no enrollment record' do
       before do
         course_settings.update(auto_approve_days: 3, auto_approve_extended_request_days: 7)
-        UserToCourse.find_by(user: user, course: course).destroy
+        Enrollment.find_by(user: user, course: course).destroy
       end
 
       it 'returns false for all requests' do
@@ -408,7 +408,7 @@ RSpec.describe Request, type: :model do
     context 'when extended student hits max_auto_approve limit' do
       before do
         course_settings.update(auto_approve_days: 3, auto_approve_extended_request_days: 7, max_auto_approve: 1)
-        UserToCourse.find_by(user: user, course: course).update!(allow_extended_requests: true)
+        Enrollment.find_by(user: user, course: course).update!(allow_extended_requests: true)
         described_class.create!(
           user: user,
           course: course,

--- a/spec/services/assignment_date_calculator_spec.rb
+++ b/spec/services/assignment_date_calculator_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe AssignmentDateCalculator, type: :service do
   end
 
   before do
-    UserToCourse.create!(user: user, course: course, role: 'student')
+    Enrollment.create!(user: user, course: course, role: 'student')
   end
 
   describe '#calculate' do


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

Renames the `UserToCourse` model, table, and all associated references to `Enrollment` throughout the codebase. The previous name was an implementation detail that didn't reflect domain language — `Enrollment` is clearer and more idiomatic.

Specifically, this includes:
- **Database**: New migration renames `user_to_courses` table to `enrollments`; schema updated accordingly
- **Models**: `UserToCourse` → `Enrollment`, `user_to_courses` associations → `enrollments` on both `Course` and `User`
- **Controllers**: `UserToCoursesController` → `EnrollmentsController`; all references to `UserToCourse` updated across `CoursesController`, `RequestsController`, `SessionController`, `CanvasFacade`, and the API controllers
- **Routes**: `resources :user_to_courses` → `resources :enrollments`
- **Views**: Updated route helpers and loop variables (`user_to_course` → `enrollment`)
- **Tests & Factories**: Renamed spec files, factory (`:user_to_course` → `:enrollment`), and all inline references

# Testing

Existing test suite covers the renamed model and controller. All specs and Cucumber step definitions have been updated to use the new naming. No behavioral changes were made — this is a pure rename refactor.

# Documentation

No external documentation changes required. Code comments referencing `UserToCourse` have been updated inline.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/khQFzt9TQF99/implementations/BGdCcNJFr9zG) | [App Preview](https://www.superconductor.com/tickets/khQFzt9TQF99/implementations/BGdCcNJFr9zG/preview) | [Guided Review](https://www.superconductor.com/tickets/khQFzt9TQF99/implementations/BGdCcNJFr9zG?tab=guided_review)

<!-- created-by-superconductor -->