### PR TITLE
Refactor Authentication: Fix Session Fixation, OmniAuth CSRF, and Cleanup Auth Logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'ostruct'
 gem 'omniauth'
 gem 'omniauth-canvas'
 gem 'omniauth-oauth2'
+# CSRF protection for the OmniAuth request phase (mitigates CVE-2015-9284)
+gem 'omniauth-rails_csrf_protection'
 
 # Audit for potentially unsafe database migrations
 gem 'strong_migrations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,9 @@ GEM
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
@@ -643,6 +646,7 @@ DEPENDENCIES
   omniauth
   omniauth-canvas
   omniauth-oauth2
+  omniauth-rails_csrf_protection
   ostruct
   pg
   puma (>= 6.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,36 +1,19 @@
 class ApplicationController < ActionController::Base
   include TokenRefreshable
 
-  before_action :authenticated!, unless: -> { excluded_controller_action? }
+  # Authentication is required everywhere by default. Controllers/actions that
+  # are legitimately public opt out with `skip_before_action :authenticated!`
+  # (see HomeController, SessionController, StatusController,
+  # Requests::ExportsController).
+  before_action :authenticated!
 
   rescue_from LmsFacade::LmsAPIError, with: :handle_lms_api_error
 
-  def excluded_controller_action?
-    # Actions and controllers that do NOT require authentication
-    excluded_actions = {
-      'home' => [ 'index' ],
-      'login' => [ 'canvas' ],
-      'session' => %w[create omniauth_callback omniauth_failure],
-      'rails/health' => [ 'show' ],
-      'requests/exports' => [ 'show' ]
-    }
-    controller = params[:controller]
-    action = params[:action]
-
-    excluded_actions[controller]&.include?(action)
-  end
-
-  # TODO: Refactor all auth methods
   helper_method :current_user
   def current_user
-    if defined?(@current_user)
-      @current_user
-    else
-      @current_user = User.find_by(canvas_uid: session[:user_id])
-    end
-    # TODO: Remove this line after refactoring all auth methods,
-    # and remove other instances of @user in controllers + views
-    @user ||= @current_user
+    return @current_user if defined?(@current_user)
+
+    @current_user = User.find_by(canvas_uid: session[:user_id])
   end
 
   # Because blazer is mounted as a module, `root_path` doesn't seem to work appropriately.
@@ -42,27 +25,28 @@ class ApplicationController < ActionController::Base
   end
 
   private
-  def authenticate_user
-    return true if current_user.present?
 
-    redirect_to root_path, alert: 'You must be logged in to access that page.'
-  end
-
-  # TODO: This needs to be refactored.
+  # The single authentication gate for the app. Runs on every controller by
+  # default (see the before_action above); public endpoints opt out with
+  # `skip_before_action :authenticated!`.
   def authenticated!
-    if session[:user_id].blank? || !Rails.env.test?
-      if current_user.nil?
-        return handle_authentication_failure('You must be logged in to access that page.')
-      elsif current_user.lms_credentials.empty?
-        return handle_authentication_failure('User has no credentials.')
-      elsif current_user.lms_credentials.first.expire_time < Time.zone.now
-        # The Canvas access token has expired. Rather than logging the user out
-        # immediately, try to use the stored (long-lived) refresh token to obtain
-        # a fresh access token so the session can continue. We only log the user
-        # out when there is no refresh token or the refresh actually fails.
-        return handle_authentication_failure('You have been logged out.') unless refresh_user_token(current_user)
-      end
+    return handle_authentication_failure('You must be logged in to access that page.') if current_user.nil?
+
+    # In the test environment a valid session user is treated as fully
+    # authenticated so specs don't have to stand up LMS credentials. Production
+    # always verifies the Canvas token below.
+    return true if Rails.env.test?
+
+    if current_user.lms_credentials.empty?
+      return handle_authentication_failure('User has no credentials.')
+    elsif current_user.lms_credentials.first.expire_time < Time.zone.now
+      # The Canvas access token has expired. Rather than logging the user out
+      # immediately, try to use the stored (long-lived) refresh token to obtain
+      # a fresh access token so the session can continue. We only log the user
+      # out when there is no refresh token or the refresh actually fails.
+      return handle_authentication_failure('You have been logged out.') unless refresh_user_token(current_user)
     end
+
     true
   rescue StandardError
     handle_authentication_failure('An unexpected error occurred.')

--- a/app/controllers/course_settings_controller.rb
+++ b/app/controllers/course_settings_controller.rb
@@ -1,6 +1,4 @@
 class CourseSettingsController < ApplicationController
-  before_action :authenticated!
-  before_action :authenticate_user
   before_action :set_course
   before_action :require_course_staff!
   before_action :set_pending_request_count

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,4 @@
 class CoursesController < ApplicationController
-  before_action :authenticate_user
   before_action :set_course, only: %i[show edit sync_assignments sync_enrollments enrollments delete]
   # Currently exclude routes that expect JSON.
   before_action :require_course_staff!, only: %i[edit enrollments delete]
@@ -47,7 +46,7 @@ class CoursesController < ApplicationController
 
     # TODO: Add spec for when a course is created, but the user is not enrolled in it.
     # TODO: Why do some courses have empty enrollments?
-    existing_canvas_ids = @user.courses.pluck(:canvas_id)
+    existing_canvas_ids = current_user.courses.pluck(:canvas_id)
     @courses_teacher = filter_courses(@courses, Enrollment.staff_roles, existing_canvas_ids)
     # Track if any teacher courses, so we still show the semester filter even if the selected semester filters out all courses.
     @has_any_teacher_courses = @courses_teacher.any?
@@ -64,25 +63,25 @@ class CoursesController < ApplicationController
   end
 
   def create
-    token = @user.lms_credentials.first.token
+    token = current_user.lms_credentials.first.token
     filter_courses(Course.fetch_courses(token), Enrollment.staff_roles)
       .select { |c| params[:courses]&.include?(c['id'].to_s) }
-      .each { |course_api| Course.create_or_update_from_canvas(course_api, token, @user) }
+      .each { |course_api| Course.create_or_update_from_canvas(course_api, token, current_user) }
     redirect_to courses_path, notice: 'Selected courses and their assignments have been imported successfully.'
   end
 
   def sync_assignments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
 
-    @course.sync_assignments(@user)
+    @course.sync_assignments(current_user)
     render json: { message: 'Assignments synced successfully.' }, status: :ok
   end
 
   def sync_enrollments
     return render json: { error: 'Course not found.' }, status: :not_found unless @course
-    return render json: { error: 'You do not have permission.' }, status: :forbidden unless @course.staff_user?(@user)
+    return render json: { error: 'You do not have permission.' }, status: :forbidden unless @course.staff_user?(current_user)
 
-    @course.sync_all_enrollments_from_canvas(@user.id)
+    @course.sync_all_enrollments_from_canvas(current_user.id)
     render json: { message: 'Users synced successfully.' }, status: :ok
   end
 

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -1,5 +1,4 @@
 class EnrollmentsController < ApplicationController
-  before_action :authenticate_user
   before_action :set_course
   before_action :ensure_course_admin
 
@@ -17,7 +16,7 @@ class EnrollmentsController < ApplicationController
   private
 
   def ensure_course_admin
-    enrollment = @course.enrollments.find_by(user: @user)
+    enrollment = @course.enrollments.find_by(user: current_user)
     return if enrollment&.course_admin?
 
     render json: { error: 'You must be an instructor or Lead TA.', redirect_to: course_path(@course) }, status: :forbidden

--- a/app/controllers/form_settings_controller.rb
+++ b/app/controllers/form_settings_controller.rb
@@ -1,6 +1,4 @@
 class FormSettingsController < ApplicationController
-  before_action :authenticated!
-  before_action :authenticate_user
   before_action :set_course
   before_action :require_course_staff!
   before_action :set_pending_request_count

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,7 @@
 class HomeController < ApplicationController
+  # The landing page is the pre-login entry point.
+  skip_before_action :authenticated!, only: :index
+
   def index
     return if session[:user_id].blank?
 

--- a/app/controllers/requests/exports_controller.rb
+++ b/app/controllers/requests/exports_controller.rb
@@ -4,6 +4,9 @@ module Requests
   # membership before_actions, authenticating solely via the course's
   # read-only API token.
   class ExportsController < ApplicationController
+    # Authenticated by the course's read-only API token, not a user session.
+    skip_before_action :authenticated!, only: :show
+
     def show
       course = Course.find_by(id: params[:course_id])
       token = params[:readonly_api_token]

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,7 +1,6 @@
 # We really should get a handle on this.
 # rubocop:disable Metrics/ClassLength
 class RequestsController < ApplicationController
-  before_action :authenticate_user
   before_action :set_course
   before_action :require_course_staff!, only: %i[create_for_student approve reject mass_approve mass_reject]
   before_action :set_form_settings
@@ -359,7 +358,7 @@ class RequestsController < ApplicationController
   rescue StandardError => e
     Rails.logger.error("Mass approve failed for request #{request.id}: #{e.message}")
     Rails.error.report(e, handled: true,
-                       context: { component: 'mass_approve', request_id: request.id, actor_id: @user&.id })
+                       context: { component: 'mass_approve', request_id: request.id, actor_id: current_user&.id })
     false
   end
 

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,4 +1,7 @@
 class SessionController < ApplicationController
+  # The OmniAuth callbacks run before a session exists, so they must be public.
+  skip_before_action :authenticated!, only: %i[omniauth_callback omniauth_failure]
+
   ## Login work flow explained here
   # Currently the login only supports third-party authentication with Canvas.
   # But the structure to support multiple login methods is largely in place.
@@ -170,6 +173,11 @@ class SessionController < ApplicationController
   def persist_login!(user, auth_token)
     user.save!
     update_user_credential(user, auth_token)
+
+    # Guard against session fixation: issue a fresh session before storing the
+    # authenticated user's identity, so any session id an attacker may have
+    # fixated is discarded at the moment of login.
+    reset_session
 
     # Store user ID in session for authentication
     session[:username] = user.name

--- a/app/views/courses/student_show.html.erb
+++ b/app/views/courses/student_show.html.erb
@@ -28,7 +28,7 @@
                   </td>
                   <td class="text-center"><%= assignment.due_date&.strftime("%a, %b %-d at %-I:%M%P") || 'N/A' %></td>
                   <td class="text-center">
-                    <% last_approved_request = @course.requests.where(user: @user, assignment_id: assignment.id, status: 'approved').order(:updated_at).last %>
+                    <% last_approved_request = @course.requests.where(user: current_user, assignment_id: assignment.id, status: 'approved').order(:updated_at).last %>
                     <% if last_approved_request.present? %>
                       <%= last_approved_request.requested_due_date.strftime("%a, %b %-d at %-I:%M%P") %>
                     <% else %>
@@ -36,7 +36,7 @@
                     <% end %>
                   </td>
                   <td class="text-center">
-                    <% existing_request = @course.requests.where(user: @user, assignment_id: assignment.id).order(updated_at: :desc).first %>
+                    <% existing_request = @course.requests.where(user: current_user, assignment_id: assignment.id).order(updated_at: :desc).first %>
                     <% if existing_request.present? %>
                       <% if existing_request.status == 'pending' %>
                         <a href="<%= course_request_path(@course, existing_request) %>" class="btn btn-sm btn-secondary">Edit</a>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,9 +22,9 @@
 			</p>
 		</div>
 		<div class="col-12 text-center">
-			<%= link_to 'Login', '/auth/canvas', class: 'btn btn-primary', id: 'login-button-index' %>
+			<%= button_to 'Login', '/auth/canvas', method: :post, class: 'btn btn-primary', id: 'login-button-index' %>
 			<% if Rails.env.development? %>
-				<%= link_to 'Developer Login', '/auth/developer', class: 'btn btn-secondary ms-2', id: 'dev-login-button' %>
+				<%= button_to 'Developer Login', '/auth/developer', method: :post, class: 'btn btn-secondary ms-2', id: 'dev-login-button' %>
 			<% end %>
 		</div>
 	</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -36,7 +36,7 @@
 					<% else %>
 						<%# TODO: Need a test case for this. %>
 						<li class="nav-item">
-							<%= link_to 'Login', '/auth/canvas', class: 'btn btn-primary', id: 'login-button-index' %>
+							<%= button_to 'Login', '/auth/canvas', method: :post, class: 'btn btn-primary', id: 'login-button-index' %>
 						</li>
 					<% end %>
 					<li>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -34,8 +34,11 @@ end
 #   Rails.logger.debug "AUTH URL: #{env['omniauth.strategy'].client.auth_code.authorize_url(authorize_params: env['omniauth.strategy'].authorize_params)}"
 # end
 
-OmniAuth.config.allowed_request_methods = [:get, :post]
-OmniAuth.config.silence_get_warning = true
+# Only allow POST to initiate the OmniAuth request phase. Combined with the
+# omniauth-rails_csrf_protection gem (which verifies the Rails CSRF token on
+# that request), this closes the CVE-2015-9284 login CSRF hole that a GET
+# request phase would otherwise expose.
+OmniAuth.config.allowed_request_methods = [:post]
 
 OmniAuth.config.on_failure = Proc.new do |env|
   OmniAuth::FailureEndpoint.new(env).redirect_to_failure

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -28,42 +28,28 @@ RSpec.describe ApplicationController, type: :controller do
     allow(controller).to receive_messages(courses_path: '/courses', root_path: '/')
   end
 
-  describe '#excluded_controller_action?' do
-    subject(:controller_instance) { controller }
-
-    {
-      'home' => 'index',
-      'login' => 'canvas',
-      'session' => 'create',
-      'rails/health' => 'show'
-    }.each do |controller, action|
-      it "excludes #{controller}##{action} from authentication" do
-        allow_any_instance_of(described_class).to receive(:params)
-          .and_return({ controller: controller, action: action })
-
-        expect(controller_instance.excluded_controller_action?).to be true
-      end
-    end
-
-    it 'does not exclude unknown controller/action' do
-      allow(controller).to receive(:params).and_return({ controller: 'courses', action: 'index' })
-
-      expect(controller.send(:excluded_controller_action?)).to be_nil
-    end
-  end
-
   describe '#authenticated!' do
     before do
       allow(Rails.env).to receive(:test?).and_return(false)
     end
 
     context 'when in test environment' do
-      it 'returns true if session user_id is set' do
+      it 'authenticates a valid session user without requiring LMS credentials' do
+        allow(Rails.env).to receive(:test?).and_return(true)
+        credential_free_user = User.create!(email: 'nocreds@example.com', canvas_uid: '999')
+        session[:user_id] = credential_free_user.canvas_uid
+
+        get :index
+        expect(response.body).to eq('OK')
+      end
+
+      it 'still rejects a session whose user does not exist' do
         allow(Rails.env).to receive(:test?).and_return(true)
         session[:user_id] = 'some-id'
 
         get :index
-        expect(response.body).to eq('OK')
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('You must be logged in to access that page.')
       end
     end
 


### PR DESCRIPTION
# General Info

- [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/########)
- [ ] Breaking?

# Changes

This PR addresses three authentication security findings from a recent audit: session fixation, OmniAuth CSRF exposure, and a brittle home-grown auth exclusion system.

**Session fixation fix (`session_controller.rb`)**
`persist_login!` now calls `reset_session` before writing `session[:user_id]`, discarding any session ID an attacker may have fixated prior to login.

**OmniAuth CSRF mitigation / CVE-2015-9284 (`config/initializers/omniauth.rb`)**
- Added the `omniauth-rails_csrf_protection` gem, which verifies the Rails CSRF token on OmniAuth request-phase POSTs.
- Restricted `allowed_request_methods` to `[:post]` only and removed `silence_get_warning`.
- Converted login `link_to` (GET) buttons to `button_to` (POST) in `home/index.html.erb` and `layouts/_navbar.html.erb` so they carry the required CSRF token.

**Auth logic consolidation (`application_controller.rb` and controllers)**
- Removed the hand-maintained `excluded_controller_action?` hash (which also contained stale entries for endpoints that no longer exist) and made `authenticated!` a plain global `before_action`.
- Public endpoints now opt out the standard Rails way with `skip_before_action :authenticated!`: `HomeController#index`, `SessionController` (OmniAuth callbacks), `Requests::ExportsController#show`, and `StatusController`.
- Removed the weaker, redundant `authenticate_user` before_action from all controllers and deleted the method itself.
- Replaced remaining `@user` references with `current_user` in controllers and views, and removed the `@user ||= @current_user` shim from `current_user`.
- Tightened `authenticated!` so a session referencing a non-existent user is always rejected — even in the test environment. The test-env short-circuit now only skips LMS credential checks (not the DB user lookup).

# Testing

- RSpec: **528 examples, 0 failures** (1 pre-existing unrelated pending).
- Cucumber (rack_test): **17 scenarios, 0 failures**.
- Updated `application_controller_spec.rb` to remove tests for the deleted `#excluded_controller_action?` method and add coverage for the corrected test-env auth behavior (valid user passes, non-existent session user is rejected).

# Documentation

No external documentation required. Inline comments in `application_controller.rb`, `session_controller.rb`, and `config/initializers/omniauth.rb` explain the security rationale for each change.

> **Note for reviewers:** `Gemfile.lock` has changed — run `bundle install` after checking out this branch.

# Checklist

- [ ] Name of branch corresponds to story

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/z9qKFfGqDhMd/implementations/wQPFKFPKTzkD) | [App Preview](https://www.superconductor.com/tickets/z9qKFfGqDhMd/implementations/wQPFKFPKTzkD/preview) | [Guided Review](https://www.superconductor.com/tickets/z9qKFfGqDhMd/implementations/wQPFKFPKTzkD?tab=guided_review)

<!-- created-by-superconductor -->